### PR TITLE
Fixes to benchmarks and added semaphore comparison

### DIFF
--- a/ants_benchmark_test.go
+++ b/ants_benchmark_test.go
@@ -43,7 +43,7 @@ const (
 )
 const (
 	RunTimes = 10000000
-	Param    = 0
+	Param    = 100
 	AntsSize = 1000
 	TestSize = 10000
 )


### PR DESCRIPTION
Benchmark results with Param=0, as time.Sleep is not stable on Windows

Also Go 1.11 has bunch of improvements:

```
goos: windows
goarch: amd64
pkg: github.com/panjf2000/ants
BenchmarkGoroutineWithFunc-8           1        3530220300 ns/op          207472 B/op        506 allocs/op
BenchmarkSemaphoreWithFunc-8           1        4391916400 ns/op           20944 B/op         57 allocs/op
BenchmarkAntsPoolWithFunc-8            1        5496395400 ns/op          164240 B/op       2059 allocs/op
BenchmarkGoroutine-8                   1        3327413400 ns/op            1552 B/op          5 allocs/op
BenchmarkSemaphore-8                   1        4499816000 ns/op            1264 B/op          5 allocs/op
BenchmarkAntsPool-8                    1        5456432100 ns/op           49208 B/op        809 allocs/op
PASS
```