### PR TITLE
bugfix(check max pool size)

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -147,7 +147,8 @@ func (p *Pool) ReSize(size int) {
 	}
 
 	if size > math.MaxInt32 {
-		return
+		// return
+		size = math.MaxInt32
 	}
 
 	atomic.StoreInt32(&p.capacity, int32(size))

--- a/pool.go
+++ b/pool.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"math"
 )
 
 type sig struct{}
@@ -144,6 +145,11 @@ func (p *Pool) ReSize(size int) {
 	if size == p.Cap() {
 		return
 	}
+
+	if size > math.MaxInt32 {
+		return
+	}
+
 	atomic.StoreInt32(&p.capacity, int32(size))
 	diff := p.Running() - size
 	for i := 0; i < diff; i++ {

--- a/pool_func.go
+++ b/pool_func.go
@@ -149,7 +149,7 @@ func (p *PoolWithFunc) ReSize(size int) {
 	}
 
 	if size > math.MaxInt32 {
-		return
+		size = math.MaxInt32
 	}
 
 	atomic.StoreInt32(&p.capacity, int32(size))

--- a/pool_func.go
+++ b/pool_func.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"math"
 )
 
 type pf func(interface{}) error
@@ -146,6 +147,11 @@ func (p *PoolWithFunc) ReSize(size int) {
 	if size == p.Cap() {
 		return
 	}
+
+	if size > math.MaxInt32 {
+		return
+	}
+
 	atomic.StoreInt32(&p.capacity, int32(size))
 	diff := p.Running() - size
 	for i := 0; i < diff; i++ {


### PR DESCRIPTION
if you limit max goroutine  to math.Maxint32 as your code `int32(pool size)`
I think should check max Goroutine size, otherwise size overflow to negative？
