### PR TITLE
Possible memory leak because of Ticker

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -62,6 +62,8 @@ type Pool struct {
 // clear expired workers periodically.
 func (p *Pool) periodicallyPurge() {
 	heartbeat := time.NewTicker(p.expiryDuration)
+	defer heartbeat.Stop()
+
 	for range heartbeat.C {
 		currentTime := time.Now()
 		p.lock.Lock()

--- a/pool_func.go
+++ b/pool_func.go
@@ -63,6 +63,8 @@ type PoolWithFunc struct {
 // clear expired workers periodically.
 func (p *PoolWithFunc) periodicallyPurge() {
 	heartbeat := time.NewTicker(p.expiryDuration)
+	defer heartbeat.Stop()
+
 	for range heartbeat.C {
 		currentTime := time.Now()
 		p.lock.Lock()


### PR DESCRIPTION
// NewTicker returns a new Ticker containing a channel that will send the
// time with a period specified by the duration argument.
// It adjusts the intervals or drops ticks to make up for slow receivers.
// The duration d must be greater than zero; if not, NewTicker will panic.
// Stop the ticker to release associated resources.
func NewTicker(d Duration) *Ticker {
……
}