### PR TITLE
goreport: lint warning on code comment structure

### DIFF
--- a/ants.go
+++ b/ants.go
@@ -39,6 +39,7 @@ const (
 var (
 	// Error types for the Ants API.
 	//---------------------------------------------------------------------------
+
 	// ErrInvalidPoolSize will be returned when setting a negative number as pool capacity.
 	ErrInvalidPoolSize = errors.New("invalid size for pool")
 


### PR DESCRIPTION
Added a newline between group comment and exported variable line 😄