### PR TITLE
optimize memory allocation, change the default pool param and add the log of panic stack.

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -1,0 +1,1 @@
+mode: atomic

--- a/worker.go
+++ b/worker.go
@@ -24,6 +24,7 @@ package ants
 
 import (
 	"log"
+	"runtime"
 	"time"
 )
 
@@ -53,7 +54,10 @@ func (w *Worker) run() {
 				if w.pool.PanicHandler != nil {
 					w.pool.PanicHandler(p)
 				} else {
-					log.Printf("worker exits from a panic: %v", p)
+					log.Printf("worker exits from a panic: %v\n", p)
+					var buf [4096]byte
+					n := runtime.Stack(buf[:], false)
+					log.Printf("worker exits from panic: %s\n", string(buf[:n]))
 				}
 			}
 		}()

--- a/worker_func.go
+++ b/worker_func.go
@@ -24,6 +24,7 @@ package ants
 
 import (
 	"log"
+	"runtime"
 	"time"
 )
 
@@ -53,7 +54,10 @@ func (w *WorkerWithFunc) run() {
 				if w.pool.PanicHandler != nil {
 					w.pool.PanicHandler(p)
 				} else {
-					log.Printf("worker exits from a panic: %v", p)
+					log.Printf("worker with func exits from a panic: %v\n", p)
+					var buf [4096]byte
+					n := runtime.Stack(buf[:], false)
+					log.Printf("worker with func exits from panic: %s\n", string(buf[:n]))
 				}
 			}
 		}()


### PR DESCRIPTION
Hi, I am using it on my online server which almost need 5 million goroutines on each go service.
I'm divided into 10 small pools, because a pool of five million will slow down the speed associated with the slice.
I made some small optimizations, I hope this is useful.
optimize memory allocation, change the default pool param and add the log of panic stack.
btw, the default value DEFAULT_CLEAN_INTERVAL_TIME, one second is too short-lived. when the pool size is too large , Performance will drop .
