### PR TITLE
Timing issue in the TestNonblockingSubmitWithFunc

### DIFF
--- a/ants_test.go
+++ b/ants_test.go
@@ -435,8 +435,8 @@ func TestNonblockingSubmitWithFunc(t *testing.T) {
 	assert.NoError(t, err, "create TimingPool failed: %v", err)
 	defer p.Release()
 	ch := make(chan struct{})
+	wg.Add(poolSize-1)
 	for i := 0; i < poolSize-1; i++ {
-	        wg.Add(1)
 		assert.NoError(t, p.Invoke(ch), "nonblocking submit when pool is not full shouldn't return error")
 	}
 	// p is full now.

--- a/ants_test.go
+++ b/ants_test.go
@@ -435,12 +435,11 @@ func TestNonblockingSubmitWithFunc(t *testing.T) {
 	assert.NoError(t, err, "create TimingPool failed: %v", err)
 	defer p.Release()
 	ch := make(chan struct{})
-	wg.Add(poolSize-1)
+	wg.Add(poolSize)
 	for i := 0; i < poolSize-1; i++ {
 		assert.NoError(t, p.Invoke(ch), "nonblocking submit when pool is not full shouldn't return error")
 	}
 	// p is full now.
-	wg.Add(1)
 	assert.NoError(t, p.Invoke(ch), "nonblocking submit when pool is not full shouldn't return error")
 	assert.EqualError(t, p.Invoke(nil), ErrPoolOverload.Error(),
 		"nonblocking submit when pool is full should get an ErrPoolOverload")


### PR DESCRIPTION
On some machines this unit would fail due to a timing issue.  Since the Invoke in the loop was using nil as the param, it would (depending on timing) lead to the workers finishing the  (w *goWorkerWithFunc) run() in the range loop over w.args as args would == nil and return. 

If an explicit time.Sleep(1 * time.Second) is added before the "	assert.EqualError(t, p.Invoke(nil), ErrPoolOverload.Error()," it is easily reproducible.

---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `ants`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?

bug-fix

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

stated above

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->

n/a

## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

n/a

## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [x] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
