### PR TITLE
Multiple Arguments Pool Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ go get -u github.com/panjf2000/ants/v2
 ## 🛠 How to use
 Just take a imagination that your program starts a massive number of goroutines, resulting in a huge consumption of memory. To mitigate that kind of situation, all you need to do is to import `ants` package and submit all your tasks to a default pool with fixed capacity, activated when package `ants` is imported:
 
-``` go
+```go
 package main
 
 import (
@@ -81,11 +81,12 @@ import (
 
 var sum int32
 
-func myFunc(i interface{}) {
-	n := i.(int32)
+func myFunc(i int32, s string) {
+	n := i
 	atomic.AddInt32(&sum, n)
-	fmt.Printf("run with %d\n", n)
+	fmt.Printf("run with %d: %s\n", n, s)
 }
+
 
 func demoFunc() {
 	time.Sleep(10 * time.Millisecond)
@@ -113,15 +114,15 @@ func main() {
 
 	// Use the pool with a function,
 	// set 10 to the capacity of goroutine pool and 1 second for expired duration.
-	p, _ := ants.NewPoolWithFunc(10, func(i interface{}) {
-		myFunc(i)
+	p, _ := ants.NewPoolWithFunc(10, func(args ...interface{}) {
+		myFunc(args[0].(int32), args[1].(string))
 		wg.Done()
 	})
 	defer p.Release()
 	// Submit tasks one by one.
 	for i := 0; i < runTimes; i++ {
 		wg.Add(1)
-		_ = p.Invoke(int32(i))
+		_ = p.Invoke(int32(i), fmt.Sprintf("hello %d", i))
 	}
 	wg.Wait()
 	fmt.Printf("running goroutines: %d\n", p.Running())

--- a/ants_benchmark_test.go
+++ b/ants_benchmark_test.go
@@ -40,9 +40,15 @@ func demoFunc() {
 	time.Sleep(time.Duration(BenchParam) * time.Millisecond)
 }
 
-func demoPoolFunc(args interface{}) {
-	n := args.(int)
+func demoPoolFunc(args ...interface{}) {
+	n := args[0].(int)
 	time.Sleep(time.Duration(n) * time.Millisecond)
+}
+
+func demoPoolMultipleArgsFunc(arg1 int, arg2 string) string {
+	n := arg1
+	time.Sleep(time.Duration(n) * time.Millisecond)
+	return arg2
 }
 
 func longRunningFunc() {
@@ -51,8 +57,8 @@ func longRunningFunc() {
 	}
 }
 
-func longRunningPoolFunc(arg interface{}) {
-	if ch, ok := arg.(chan struct{}); ok {
+func longRunningPoolFunc(args ...interface{}) {
+	if ch, ok := args[0].(chan struct{}); ok {
 		<-ch
 		return
 	}

--- a/examples/main.go
+++ b/examples/main.go
@@ -33,10 +33,10 @@ import (
 
 var sum int32
 
-func myFunc(i interface{}) {
-	n := i.(int32)
+func myFunc(i int32, s string) {
+	n := i
 	atomic.AddInt32(&sum, n)
-	fmt.Printf("run with %d\n", n)
+	fmt.Printf("run with %d: %s\n", n, s)
 }
 
 func demoFunc() {
@@ -66,14 +66,14 @@ func main() {
 	// Use the pool with a method,
 	// set 10 to the capacity of goroutine pool and 1 second for expired duration.
 	p, _ := ants.NewPoolWithFunc(10, func(args ...interface{}) {
-		myFunc(args[0])
+		myFunc(args[0].(int32), args[1].(string))
 		wg.Done()
 	})
 	defer p.Release()
 	// Submit tasks one by one.
 	for i := 0; i < runTimes; i++ {
 		wg.Add(1)
-		_ = p.Invoke(int32(i))
+		_ = p.Invoke(int32(i), fmt.Sprintf("hello %d", i))
 	}
 	wg.Wait()
 	fmt.Printf("running goroutines: %d\n", p.Running())

--- a/examples/main.go
+++ b/examples/main.go
@@ -65,8 +65,8 @@ func main() {
 
 	// Use the pool with a method,
 	// set 10 to the capacity of goroutine pool and 1 second for expired duration.
-	p, _ := ants.NewPoolWithFunc(10, func(i interface{}) {
-		myFunc(i)
+	p, _ := ants.NewPoolWithFunc(10, func(args ...interface{}) {
+		myFunc(args[0])
 		wg.Done()
 	})
 	defer p.Release()

--- a/pool_func.go
+++ b/pool_func.go
@@ -53,7 +53,7 @@ type PoolWithFunc struct {
 	cond *sync.Cond
 
 	// poolFunc is the function for processing tasks.
-	poolFunc func(interface{})
+	poolFunc func(...interface{})
 
 	// workerCache speeds up the obtainment of a usable worker in function:retrieveWorker.
 	workerCache sync.Pool
@@ -124,7 +124,7 @@ func (p *PoolWithFunc) purgePeriodically(ctx context.Context) {
 }
 
 // NewPoolWithFunc generates an instance of ants pool with a specific function.
-func NewPoolWithFunc(size int, pf func(interface{}), options ...Option) (*PoolWithFunc, error) {
+func NewPoolWithFunc(size int, pf func(...interface{}), options ...Option) (*PoolWithFunc, error) {
 	if size <= 0 {
 		size = -1
 	}
@@ -184,7 +184,7 @@ func NewPoolWithFunc(size int, pf func(interface{}), options ...Option) (*PoolWi
 // but what calls for special attention is that you will get blocked with the latest
 // Pool.Invoke() call once the current Pool runs out of its capacity, and to avoid this,
 // you should instantiate a PoolWithFunc with ants.WithNonblocking(true).
-func (p *PoolWithFunc) Invoke(args interface{}) error {
+func (p *PoolWithFunc) Invoke(args ...interface{}) error {
 	if p.IsClosed() {
 		return ErrPoolClosed
 	}

--- a/worker_func.go
+++ b/worker_func.go
@@ -67,7 +67,7 @@ func (w *goWorkerWithFunc) run() {
 			if args == nil {
 				return
 			}
-			w.pool.poolFunc(args)
+			w.pool.poolFunc(args.([]interface{})...)
 			if ok := w.pool.revertWorker(w); !ok {
 				return
 			}


### PR DESCRIPTION
… Invoke function without explicitly creating an array

---
name: Pull request
about: Propose changes to the code
title: 'Multiple arguments pool func'
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `ants`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature? Optimizations



## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
To schedule a function with multiple arguments got a little bit ugly when creating an array to pass as an argument, then casting the interface{} to an array again and retrieving the single args. This slight change helps the developer to easily invoke its function passing multiple arguments and receiving directly the array of args. This of course means that single arg functions still have to parse the arg with arg[0]


## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->



## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->
Mainly just the code used as an example, the updated README is included with the PR


## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [x] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
