### PR TITLE
bug: fix the missing log.Lmsgprefix in go1.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.13'
+          go-version: ${{ matrix.go }}
 
       - name: Print Go environment
         id: go-env

--- a/ants.go
+++ b/ants.go
@@ -81,8 +81,10 @@ var (
 		// since otherwise the sender might be dragged down if the receiver is CPU-bound.
 		return 1
 	}()
-
-	defaultLogger = Logger(log.New(os.Stderr, "[ants]: ", log.LstdFlags|log.Lmsgprefix|log.Lmicroseconds))
+	
+	// Quick fix: go version 1.13 do not support log.Lmsgprefix
+	fix_log_Lmsgprefix = 64
+	defaultLogger = Logger(log.New(os.Stderr, "[ants]: ", log.LstdFlags|fix_log_Lmsgprefix|log.Lmicroseconds))
 
 	// Init an instance pool when importing ants.
 	defaultAntsPool, _ = NewPool(DefaultAntsPoolSize)

--- a/ants.go
+++ b/ants.go
@@ -81,10 +81,10 @@ var (
 		// since otherwise the sender might be dragged down if the receiver is CPU-bound.
 		return 1
 	}()
-	
-	// Quick fix: go version 1.13 do not support log.Lmsgprefix
-	fix_log_Lmsgprefix = 64
-	defaultLogger = Logger(log.New(os.Stderr, "[ants]: ", log.LstdFlags|fix_log_Lmsgprefix|log.Lmicroseconds))
+
+	// log.Lmsgprefix is not available in go1.13, just make an identical value for it.
+	logLmsgprefix = 64
+	defaultLogger = Logger(log.New(os.Stderr, "[ants]: ", log.LstdFlags|logLmsgprefix|log.Lmicroseconds))
 
 	// Init an instance pool when importing ants.
 	defaultAntsPool, _ = NewPool(DefaultAntsPoolSize)


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `ants`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?

bug-fixs

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

暂时先在 ants.go 里自定义了一个 log.Lmsgprefix 的值 64 。

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->

[[Bug]: go.mod 中的go version(1.13)和ants.go存在不匹配 #274](https://github.com/panjf2000/ants/issues/274)

## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

ants.go

## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [x] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
