### PR TITLE
feat: add a new API `ReleaseTimeout` for the default pool

### DIFF
--- a/ants.go
+++ b/ants.go
@@ -123,6 +123,11 @@ func Release() {
 	defaultAntsPool.Release()
 }
 
+// ReleaseTimeout is like Release but with a timeout, it waits all workers to exit before timing out.
+func ReleaseTimeout(timeout time.Duration) error {
+	return defaultAntsPool.ReleaseTimeout(timeout)
+}
+
 // Reboot reboots the default pool.
 func Reboot() {
 	defaultAntsPool.Reboot()

--- a/ants_test.go
+++ b/ants_test.go
@@ -973,3 +973,15 @@ func TestReleaseTimeout(t *testing.T) {
 	err = pf.ReleaseTimeout(2 * time.Second)
 	assert.NoError(t, err)
 }
+
+func TestDefaultPoolReleaseTimeout(t *testing.T) {
+	Reboot()
+	for i := 0; i < 5; i++ {
+		_ = Submit(func() {
+			time.Sleep(time.Second)
+		})
+	}
+	assert.NotZero(t, Running())
+	err := ReleaseTimeout(2 * time.Second)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION


---
name: 'Unblock goPurge and goTicktock in defaultAntsPool'
about: ants.Release() calls defaultAntsPool.Release() which leaves goPurge and goTicktock still running in the background. ants.Release() should close the context for goPurge and goTicktock. This can be accomplished by calling defaultAntsPool.ReleaseTimeout().
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `ants`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?

new feature

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

goPurge and goTicktock are left on the stack because there is no way to close those methods started by the defaultAntsPool. This PR should add a fix for that.

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->

https://github.com/panjf2000/ants/issues/244

## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [x] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
