### PR TITLE
opt: fix the potential goroutine leak after calling `Release()`

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -273,6 +273,10 @@ func (p *Pool) IsClosed() bool {
 
 // Release closes this pool and releases the worker queue.
 func (p *Pool) Release() {
+	if !atomic.CompareAndSwapInt32(&p.state, OPENED, CLOSED) {
+		return
+	}
+
 	if p.stopPurge != nil {
 		p.stopPurge()
 		p.stopPurge = nil
@@ -280,9 +284,6 @@ func (p *Pool) Release() {
 	p.stopTicktock()
 	p.stopTicktock = nil
 
-	if !atomic.CompareAndSwapInt32(&p.state, OPENED, CLOSED) {
-		return
-	}
 	p.lock.Lock()
 	p.workers.reset()
 	p.lock.Unlock()

--- a/pool_func.go
+++ b/pool_func.go
@@ -279,6 +279,10 @@ func (p *PoolWithFunc) IsClosed() bool {
 
 // Release closes this pool and releases the worker queue.
 func (p *PoolWithFunc) Release() {
+	if !atomic.CompareAndSwapInt32(&p.state, OPENED, CLOSED) {
+		return
+	}
+
 	if p.stopPurge != nil {
 		p.stopPurge()
 		p.stopPurge = nil
@@ -286,9 +290,6 @@ func (p *PoolWithFunc) Release() {
 	p.stopTicktock()
 	p.stopTicktock = nil
 
-	if !atomic.CompareAndSwapInt32(&p.state, OPENED, CLOSED) {
-		return
-	}
 	p.lock.Lock()
 	p.workers.reset()
 	p.lock.Unlock()


### PR DESCRIPTION
…rom Release method

---
name: Refactor Release Methods
about: Call cleanup functions when Release() is called. 
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `ants`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?
Bug fix.


## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
By moving stopTicktock and stopPurge into Release() methods from ReleaseTimeout(), these functions will be stopped when Release() is called. 


## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->
https://github.com/panjf2000/ants/issues/244


## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [x] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
