### PR TITLE
refactor: refine the code in `retrieveWorker` to make it more readable

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -333,11 +333,6 @@ func (p *Pool) addWaiting(delta int) {
 
 // retrieveWorker returns an available worker to run the tasks.
 func (p *Pool) retrieveWorker() (w worker) {
-	spawnWorker := func() {
-		w = p.workerCache.Get().(*goWorker)
-		w.run()
-	}
-
 	p.lock.Lock()
 
 retry:
@@ -351,7 +346,8 @@ retry:
 	// then just spawn a new worker goroutine.
 	if capacity := p.Cap(); capacity == -1 || capacity > p.Running() {
 		p.lock.Unlock()
-		spawnWorker()
+		w = p.workerCache.Get().(*goWorker)
+		w.run()
 		return
 	}
 

--- a/pool.go
+++ b/pool.go
@@ -341,21 +341,21 @@ func (p *Pool) retrieveWorker() (w worker) {
 	p.lock.Lock()
 
 retry:
+	// First try to fetch the worker from the queue
 	if w = p.workers.detach(); w != nil {
-		// first try to fetch the worker from the queue
 		p.lock.Unlock()
 		return
 	}
 
+	// If the worker queue is empty and we don't run out of the pool capacity,
+	// then just spawn a new worker goroutine.
 	if capacity := p.Cap(); capacity == -1 || capacity > p.Running() {
-		// if the worker queue is empty and we don't run out of the pool capacity,
-		// then just spawn a new worker goroutine.
 		p.lock.Unlock()
 		spawnWorker()
 		return
 	}
 
-	// otherwise, we'll have to keep them blocked and wait for at least one worker to be put back into pool.
+	// Otherwise, we'll have to keep them blocked and wait for at least one worker to be put back into pool.
 	if p.options.Nonblocking {
 		p.lock.Unlock()
 		return

--- a/pool.go
+++ b/pool.go
@@ -341,7 +341,7 @@ func (p *Pool) retrieveWorker() (w worker) {
 	p.lock.Lock()
 
 retry:
-	// First try to fetch the worker from the queue
+	// First try to fetch the worker from the queue.
 	if w = p.workers.detach(); w != nil {
 		p.lock.Unlock()
 		return

--- a/pool.go
+++ b/pool.go
@@ -339,45 +339,43 @@ func (p *Pool) retrieveWorker() (w worker) {
 	}
 
 	p.lock.Lock()
-	w = p.workers.detach()
-	if w != nil { // first try to fetch the worker from the queue
+
+retry:
+	if w = p.workers.detach(); w != nil {
+		// first try to fetch the worker from the queue
 		p.lock.Unlock()
-	} else if capacity := p.Cap(); capacity == -1 || capacity > p.Running() {
+		return
+	}
+
+	if capacity := p.Cap(); capacity == -1 || capacity > p.Running() {
 		// if the worker queue is empty and we don't run out of the pool capacity,
 		// then just spawn a new worker goroutine.
 		p.lock.Unlock()
 		spawnWorker()
-	} else { // otherwise, we'll have to keep them blocked and wait for at least one worker to be put back into pool.
-		if p.options.Nonblocking {
-			p.lock.Unlock()
-			return
-		}
-	retry:
-		if p.options.MaxBlockingTasks != 0 && p.Waiting() >= p.options.MaxBlockingTasks {
-			p.lock.Unlock()
-			return
-		}
-
-		p.addWaiting(1)
-		p.cond.Wait() // block and wait for an available worker
-		p.addWaiting(-1)
-
-		if p.IsClosed() {
-			p.lock.Unlock()
-			return
-		}
-
-		if w = p.workers.detach(); w == nil {
-			if p.Free() > 0 {
-				p.lock.Unlock()
-				spawnWorker()
-				return
-			}
-			goto retry
-		}
-		p.lock.Unlock()
+		return
 	}
-	return
+
+	// otherwise, we'll have to keep them blocked and wait for at least one worker to be put back into pool.
+	if p.options.Nonblocking {
+		p.lock.Unlock()
+		return
+	}
+
+	if p.options.MaxBlockingTasks != 0 && p.Waiting() >= p.options.MaxBlockingTasks {
+		p.lock.Unlock()
+		return
+	}
+
+	p.addWaiting(1)
+	p.cond.Wait() // block and wait for an available worker
+	p.addWaiting(-1)
+
+	if p.IsClosed() {
+		p.lock.Unlock()
+		return
+	}
+
+	goto retry
 }
 
 // revertWorker puts a worker back into free pool, recycling the goroutines.

--- a/pool_func.go
+++ b/pool_func.go
@@ -347,7 +347,7 @@ func (p *PoolWithFunc) retrieveWorker() (w worker) {
 	p.lock.Lock()
 
 retry:
-	// First try to fetch the worker from the queue
+	// First try to fetch the worker from the queue.
 	if w = p.workers.detach(); w != nil {
 		p.lock.Unlock()
 		return

--- a/pool_func.go
+++ b/pool_func.go
@@ -361,17 +361,13 @@ retry:
 		return
 	}
 
+	// Bail out early if it's in nonblocking mode or the number of pending callers reaches the maximum limit value.
+	if p.options.Nonblocking || (p.options.MaxBlockingTasks != 0 && p.Waiting() >= p.options.MaxBlockingTasks) {
+		p.lock.Unlock()
+		return
+	}
+
 	// Otherwise, we'll have to keep them blocked and wait for at least one worker to be put back into pool.
-	if p.options.Nonblocking {
-		p.lock.Unlock()
-		return
-	}
-
-	if p.options.MaxBlockingTasks != 0 && p.Waiting() >= p.options.MaxBlockingTasks {
-		p.lock.Unlock()
-		return
-	}
-
 	p.addWaiting(1)
 	p.cond.Wait() // block and wait for an available worker
 	p.addWaiting(-1)

--- a/pool_func.go
+++ b/pool_func.go
@@ -339,11 +339,6 @@ func (p *PoolWithFunc) addWaiting(delta int) {
 
 // retrieveWorker returns an available worker to run the tasks.
 func (p *PoolWithFunc) retrieveWorker() (w worker) {
-	spawnWorker := func() {
-		w = p.workerCache.Get().(*goWorkerWithFunc)
-		w.run()
-	}
-
 	p.lock.Lock()
 
 retry:
@@ -357,7 +352,8 @@ retry:
 	// then just spawn a new worker goroutine.
 	if capacity := p.Cap(); capacity == -1 || capacity > p.Running() {
 		p.lock.Unlock()
-		spawnWorker()
+		w = p.workerCache.Get().(*goWorkerWithFunc)
+		w.run()
 		return
 	}
 


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: 'make func of retrieveWorker() more readable.'
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `ants`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?
refactor

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

I noticed that when I call `retrieveWorker()`, it processes two repetitive functions: `detach()` and `capacity == -1 || capacity > p.Running()` in the `else` block.
Thus, I move the `retry` label to the first instance of the `detach()` function and made a little change of if-else block.
It didn't affect the logic, but it is more readable.

`before`
```go
// retrieveWorker returns an available worker to run the tasks.
func (p *Pool) retrieveWorker() (w worker) {
	spawnWorker := func() {
		w = p.workerCache.Get().(*goWorker)
		w.run()
	}

	p.lock.Lock()
	w = p.workers.detach()
	if w != nil { // first try to fetch the worker from the queue
		p.lock.Unlock()
	} else if capacity := p.Cap(); capacity == -1 || capacity > p.Running() {
		// if the worker queue is empty and we don't run out of the pool capacity,
		// then just spawn a new worker goroutine.
		p.lock.Unlock()
		spawnWorker()
	} else { // otherwise, we'll have to keep them blocked and wait for at least one worker to be put back into pool.
		if p.options.Nonblocking {
			p.lock.Unlock()
			return
		}
	retry:
		if p.options.MaxBlockingTasks != 0 && p.Waiting() >= p.options.MaxBlockingTasks {
			p.lock.Unlock()
			return
		}

		p.addWaiting(1)
		p.cond.Wait() // block and wait for an available worker
		p.addWaiting(-1)

		if p.IsClosed() {
			p.lock.Unlock()
			return
		}

		if w = p.workers.detach(); w == nil {
			if p.Free() > 0 {
				p.lock.Unlock()
				spawnWorker()
				return
			}
			goto retry
		}
		p.lock.Unlock()
	}
	return
}
```
`after`
```go
// retrieveWorker returns an available worker to run the tasks.
func (p *Pool) retrieveWorker() (w worker) {
	spawnWorker := func() {
		w = p.workerCache.Get().(*goWorker)
		w.run()
	}

	p.lock.Lock()

retry:
	if w = p.workers.detach(); w != nil {
		// first try to fetch the worker from the queue
		p.lock.Unlock()
		return
	}

	if capacity := p.Cap(); capacity == -1 || capacity > p.Running() {
		// if the worker queue is empty and we don't run out of the pool capacity,
		// then just spawn a new worker goroutine.
		p.lock.Unlock()
		spawnWorker()
		return
	}

	// otherwise, we'll have to keep them blocked and wait for at least one worker to be put back into pool.
	if p.options.Nonblocking {
		p.lock.Unlock()
		return
	}

	if p.options.MaxBlockingTasks != 0 && p.Waiting() >= p.options.MaxBlockingTasks {
		p.lock.Unlock()
		return
	}

	p.addWaiting(1)
	p.cond.Wait() // block and wait for an available worker
	p.addWaiting(-1)

	if p.IsClosed() {
		p.lock.Unlock()
		return
	}

	goto retry
}
```

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->
No


## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->
No


## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [x] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
