### PR TITLE
bug: return error before creating multi pools if lbs is invalid to avoid leaks

### DIFF
--- a/multipool.go
+++ b/multipool.go
@@ -56,6 +56,9 @@ type MultiPool struct {
 // NewMultiPool instantiates a MultiPool with a size of the pool list and a size
 // per pool, and the load-balancing strategy.
 func NewMultiPool(size, sizePerPool int, lbs LoadBalancingStrategy, options ...Option) (*MultiPool, error) {
+	if lbs != RoundRobin && lbs != LeastTasks {
+		return nil, ErrInvalidLoadBalancingStrategy
+	}
 	pools := make([]*Pool, size)
 	for i := 0; i < size; i++ {
 		pool, err := NewPool(sizePerPool, options...)
@@ -63,9 +66,6 @@ func NewMultiPool(size, sizePerPool int, lbs LoadBalancingStrategy, options ...O
 			return nil, err
 		}
 		pools[i] = pool
-	}
-	if lbs != RoundRobin && lbs != LeastTasks {
-		return nil, ErrInvalidLoadBalancingStrategy
 	}
 	return &MultiPool{pools: pools, lbs: lbs}, nil
 }

--- a/multipool_func.go
+++ b/multipool_func.go
@@ -45,6 +45,9 @@ type MultiPoolWithFunc struct {
 // NewMultiPoolWithFunc instantiates a MultiPoolWithFunc with a size of the pool list and a size
 // per pool, and the load-balancing strategy.
 func NewMultiPoolWithFunc(size, sizePerPool int, fn func(interface{}), lbs LoadBalancingStrategy, options ...Option) (*MultiPoolWithFunc, error) {
+	if lbs != RoundRobin && lbs != LeastTasks {
+		return nil, ErrInvalidLoadBalancingStrategy
+	}
 	pools := make([]*PoolWithFunc, size)
 	for i := 0; i < size; i++ {
 		pool, err := NewPoolWithFunc(sizePerPool, fn, options...)
@@ -52,9 +55,6 @@ func NewMultiPoolWithFunc(size, sizePerPool int, fn func(interface{}), lbs LoadB
 			return nil, err
 		}
 		pools[i] = pool
-	}
-	if lbs != RoundRobin && lbs != LeastTasks {
-		return nil, ErrInvalidLoadBalancingStrategy
 	}
 	return &MultiPoolWithFunc{pools: pools, lbs: lbs}, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to `ants`! Please fill this out to help us review your pull request more efficiently.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?
Yes, for small optimization of multi pools. 


## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
If lbs is invalid then we should immediately return from `NewMultiPool` func instead of creating pool arrays and then check for lbs validation


## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->
NA


## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->
NA


## 4. Checklist

- [x] I have squashed all insignificant commits.
- [ ] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
