### PR TITLE
opt: using anonymous functions to keep goroutines alive after a panic

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -46,25 +46,22 @@ type goWorker struct {
 func (w *goWorker) run() {
 	w.pool.addRunning(1)
 	go func() {
-		defer func() {
-			w.pool.addRunning(-1)
-			w.pool.workerCache.Put(w)
-			if p := recover(); p != nil {
-				if ph := w.pool.options.PanicHandler; ph != nil {
-					ph(p)
-				} else {
-					w.pool.options.Logger.Printf("worker exits from panic: %v\n%s\n", p, debug.Stack())
-				}
-			}
-			// Call Signal() here in case there are goroutines waiting for available workers.
-			w.pool.cond.Signal()
-		}()
-
 		for f := range w.task {
 			if f == nil {
 				return
 			}
-			f()
+			func() {
+				defer func() {
+					if p := recover(); p != nil {
+						if ph := w.pool.options.PanicHandler; ph != nil {
+							ph(p)
+						} else {
+							w.pool.options.Logger.Printf("worker exits from panic: %v\n%s\n", p, debug.Stack())
+						}
+					}
+				}()
+				f()
+			}()
 			if ok := w.pool.revertWorker(w); !ok {
 				return
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to `ants`! Please fill this out to help us review your pull request more efficiently.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?
optimizations


## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
In scenarios where panics occur frequently, by using anonymous functions to keep the goroutine alive, one can reduce the repeated creation of goroutines. Here are my benchmark results：
![lQLPJw56Chp5HJ3NAdvNBZ6wqo8qFrqXrO0F8aJ0_7lrAQ_1438_475](https://github.com/panjf2000/ants/assets/54785329/4c94d881-46ad-466d-9c1e-f418e0235151)
![lQLPJx4SuKEJfJ3NAg7NBX2wDFj_kjvlAYMF8aJ0_7lrAA_1405_526](https://github.com/panjf2000/ants/assets/54785329/0dfc0be8-cae0-468f-aac6-76a27d2dd3be)



## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->



## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [ ] I have squashed all insignificant commits.
- [ ] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [ ] (optional) I am willing to help maintain this change if there are issues with it later.
