### PR TITLE
ci: replace macos-latest with macos-12 for go1.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.13, 1.21]
+        go: [1.13, 1.22]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - go: 1.13
+            os: macos-13
+        exclude:
+          # Starting macOS 14 GitHub Actions runners are arm-based,
+          # but Go didn't support arm64 until 1.16. Thus, we must
+          # replace the macOS 14 runner with macOS 13 runner for Go 1.13.
+          # Ref: https://github.com/actions/runner-images/issues/9741
+          - go: 1.13
+            os: macos-latest
     name: Go ${{ matrix.go }} @ ${{ matrix.os }}
     runs-on: ${{ matrix.os}}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,16 @@ jobs:
         go: [1.13, 1.22]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
+          # TODO(panjf2000): There is an uncanny issue arising when downloading
+          # go modules on macOS 13 for Go1.13. So we use macOS 12 for now,
+          # but try to figure it out and use macOS once it's resolved.
+          # https://github.com/panjf2000/ants/actions/runs/9546726268/job/26310385582
           - go: 1.13
-            os: macos-13
+            os: macos-12
         exclude:
           # Starting macOS 14 GitHub Actions runners are arm-based,
           # but Go didn't support arm64 until 1.16. Thus, we must
-          # replace the macOS 14 runner with macOS 13 runner for Go 1.13.
+          # replace the macOS 14 runner with macOS 12 runner for Go 1.13.
           # Ref: https://github.com/actions/runner-images/issues/9741
           - go: 1.13
             os: macos-latest


### PR DESCRIPTION
Updates:

There is an [uncanny issue](https://github.com/panjf2000/ants/actions/runs/9546726268/job/26310385582) arising when downloading go modules on macOS 13 for Go1.13. So we use macOS 12 for now.

---

Starting macOS 14 GitHub Actions runners are arm-based but Go didn't support arm64 until 1.16, which will result in [some CI failure](https://github.com/panjf2000/ants/actions/runs/9545685155/job/26306999794) after the `macos-latest` had been migrated from macOS 12 to 14. Thus, we must replace the macOS 14 runner with the macOS 13 runner for Go 1.13.

Check out https://github.com/actions/runner-images/issues/9741 for more details.