### PR TITLE
bug: fix lock unlock position in worker goroutine spawning

### DIFF
--- a/ants.go
+++ b/ants.go
@@ -472,9 +472,9 @@ retry:
 	// If the worker queue is empty, and we don't run out of the pool capacity,
 	// then just spawn a new worker goroutine.
 	if capacity := p.Cap(); capacity == -1 || capacity > p.Running() {
-		p.lock.Unlock()
 		w = p.workerCache.Get().(worker)
 		w.run()
+		p.lock.Unlock()
 		return
 	}
 


### PR DESCRIPTION
Follow up https://github.com/panjf2000/ants/issues/374


> Instead of adding this p.addRunning(1) and removing p.addRunning(-1) from all worker implementations. Can we just simply move p.lock.Unlock() underneath w.run()?

yes. great.