### PR TITLE
use Unix Nano timestamp for "now" in poolCommon

### DIFF
--- a/ants.go
+++ b/ants.go
@@ -191,7 +191,7 @@ type poolCommon struct {
 	ticktockCtx  context.Context
 	stopTicktock context.CancelFunc
 
-	now atomic.Value
+	now int64
 
 	options *Options
 }
@@ -303,7 +303,7 @@ func (p *poolCommon) ticktock() {
 			break
 		}
 
-		p.now.Store(time.Now())
+		atomic.StoreInt64(&p.now, time.Now().UnixNano())
 	}
 }
 
@@ -318,13 +318,13 @@ func (p *poolCommon) goPurge() {
 }
 
 func (p *poolCommon) goTicktock() {
-	p.now.Store(time.Now())
+	atomic.StoreInt64(&p.now, time.Now().UnixNano())
 	p.ticktockCtx, p.stopTicktock = context.WithCancel(context.Background())
 	go p.ticktock()
 }
 
 func (p *poolCommon) nowTime() time.Time {
-	return p.now.Load().(time.Time)
+	return time.Unix(0, atomic.LoadInt64(&p.now))
 }
 
 // Running returns the number of workers currently running.


### PR DESCRIPTION
The pool’s ticktock goroutine was storing time.Now() in an atomic.Value, which incurs interface boxing and shows up as runtime.convT in profiles. Switch to storing Unix nanos in an int64 with atomic.Load/StoreInt64, and reconstruct time.Time in nowTime(). This preserves behavior while removing the per‑tick allocation and conversion overhead, especially when many pools are created.

<!--
Thank you for contributing to `ants`! Please fill this out to help us review your pull request more efficiently.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?

This is an optimization.

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Each ants pool runs a ticktock() goroutine that periodically caches time.Now() in an atomic.Value. With many pools, the repeated interface boxing and atomic.Value store shows up as runtime.convT in CPU profiles and adds measurable overhead. By switching the cached value to a plain int64 holding Unix nanoseconds and using atomic.StoreInt64/LoadInt64, we keep the same cached‑time behavior for worker expiry but remove the conversion and allocation cost. This reduces per‑pool CPU overhead while preserving existing semantics for idle worker expiration.

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->



## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [x] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
