### PR TITLE
use UnixNano for worker timestamps

### DIFF
--- a/ants.go
+++ b/ants.go
@@ -323,8 +323,8 @@ func (p *poolCommon) goTicktock() {
 	go p.ticktock()
 }
 
-func (p *poolCommon) nowTime() time.Time {
-	return time.Unix(0, atomic.LoadInt64(&p.now))
+func (p *poolCommon) nowTime() int64 {
+	return atomic.LoadInt64(&p.now)
 }
 
 // Running returns the number of workers currently running.

--- a/worker.go
+++ b/worker.go
@@ -24,7 +24,6 @@ package ants
 
 import (
 	"runtime/debug"
-	"time"
 )
 
 // goWorker is the actual executor who runs the tasks,
@@ -40,7 +39,7 @@ type goWorker struct {
 	task chan func()
 
 	// lastUsed will be updated when putting a worker back into queue.
-	lastUsed time.Time
+	lastUsed int64
 }
 
 // run starts a goroutine to repeat the process
@@ -82,11 +81,11 @@ func (w *goWorker) finish() {
 	w.task <- nil
 }
 
-func (w *goWorker) lastUsedTime() time.Time {
+func (w *goWorker) lastUsedTime() int64 {
 	return w.lastUsed
 }
 
-func (w *goWorker) setLastUsedTime(t time.Time) {
+func (w *goWorker) setLastUsedTime(t int64) {
 	w.lastUsed = t
 }
 

--- a/worker_func.go
+++ b/worker_func.go
@@ -24,7 +24,6 @@ package ants
 
 import (
 	"runtime/debug"
-	"time"
 )
 
 // goWorkerWithFunc is the actual executor who runs the tasks,
@@ -40,7 +39,7 @@ type goWorkerWithFunc struct {
 	arg chan any
 
 	// lastUsed will be updated when putting a worker back into queue.
-	lastUsed time.Time
+	lastUsed int64
 }
 
 // run starts a goroutine to repeat the process
@@ -82,11 +81,11 @@ func (w *goWorkerWithFunc) finish() {
 	w.arg <- nil
 }
 
-func (w *goWorkerWithFunc) lastUsedTime() time.Time {
+func (w *goWorkerWithFunc) lastUsedTime() int64 {
 	return w.lastUsed
 }
 
-func (w *goWorkerWithFunc) setLastUsedTime(t time.Time) {
+func (w *goWorkerWithFunc) setLastUsedTime(t int64) {
 	w.lastUsed = t
 }
 

--- a/worker_func_generic.go
+++ b/worker_func_generic.go
@@ -24,7 +24,6 @@ package ants
 
 import (
 	"runtime/debug"
-	"time"
 )
 
 // goWorkerWithFunc is the actual executor who runs the tasks,
@@ -43,7 +42,7 @@ type goWorkerWithFuncGeneric[T any] struct {
 	exit chan struct{}
 
 	// lastUsed will be updated when putting a worker back into queue.
-	lastUsed time.Time
+	lastUsed int64
 }
 
 // run starts a goroutine to repeat the process
@@ -87,10 +86,10 @@ func (w *goWorkerWithFuncGeneric[T]) finish() {
 	w.exit <- struct{}{}
 }
 
-func (w *goWorkerWithFuncGeneric[T]) lastUsedTime() time.Time {
+func (w *goWorkerWithFuncGeneric[T]) lastUsedTime() int64 {
 	return w.lastUsed
 }
 
-func (w *goWorkerWithFuncGeneric[T]) setLastUsedTime(t time.Time) {
+func (w *goWorkerWithFuncGeneric[T]) setLastUsedTime(t int64) {
 	w.lastUsed = t
 }

--- a/worker_loop_queue.go
+++ b/worker_loop_queue.go
@@ -92,7 +92,7 @@ func (wq *loopQueue) detach() worker {
 }
 
 func (wq *loopQueue) refresh(duration time.Duration) []worker {
-	expiryTime := time.Now().Add(-duration)
+	expiryTime := time.Now().Add(-duration).UnixNano()
 	index := wq.binarySearch(expiryTime)
 	if index == -1 {
 		return nil
@@ -123,12 +123,12 @@ func (wq *loopQueue) refresh(duration time.Duration) []worker {
 	return wq.expiry
 }
 
-func (wq *loopQueue) binarySearch(expiryTime time.Time) int {
+func (wq *loopQueue) binarySearch(expiryTime int64) int {
 	var mid, nlen, basel, tmid int
 	nlen = len(wq.items)
 
 	// if no need to remove work, return -1
-	if wq.isEmpty() || expiryTime.Before(wq.items[wq.head].lastUsedTime()) {
+	if wq.isEmpty() || expiryTime < wq.items[wq.head].lastUsedTime() {
 		return -1
 	}
 
@@ -150,7 +150,7 @@ func (wq *loopQueue) binarySearch(expiryTime time.Time) int {
 		mid = l + ((r - l) >> 1) // avoid overflow when computing mid
 		// calculate true mid position from mapped mid position
 		tmid = (mid + basel + nlen) % nlen
-		if expiryTime.Before(wq.items[tmid].lastUsedTime()) {
+		if expiryTime < wq.items[tmid].lastUsedTime() {
 			r = mid - 1
 		} else {
 			l = mid + 1

--- a/worker_loop_queue_test.go
+++ b/worker_loop_queue_test.go
@@ -45,7 +45,7 @@ func TestLoopQueue(t *testing.T) {
 	q := newWorkerLoopQueue(size)
 
 	for i := 0; i < 5; i++ {
-		err := q.insert(&goWorker{lastUsed: time.Now()})
+		err := q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 		if err != nil {
 			break
 		}
@@ -57,14 +57,14 @@ func TestLoopQueue(t *testing.T) {
 	time.Sleep(time.Second)
 
 	for i := 0; i < 6; i++ {
-		err := q.insert(&goWorker{lastUsed: time.Now()})
+		err := q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 		if err != nil {
 			break
 		}
 	}
 	require.EqualValues(t, 10, q.len(), "Len error")
 
-	err := q.insert(&goWorker{lastUsed: time.Now()})
+	err := q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 	require.Error(t, err, "Enqueue, error")
 
 	q.refresh(time.Second)
@@ -79,35 +79,42 @@ func TestRotatedQueueSearch(t *testing.T) {
 	size := 10
 	q := newWorkerLoopQueue(size)
 
+	currTime := time.Now().UnixNano()
+
 	// 1
-	expiry1 := time.Now()
+	expiry1 := currTime
+	currTime++
+	_ = q.insert(&goWorker{lastUsed: currTime})
 
-	_ = q.insert(&goWorker{lastUsed: time.Now()})
-
-	require.EqualValues(t, 0, q.binarySearch(time.Now()), "index should be 0")
+	require.EqualValues(t, 0, q.binarySearch(currTime), "index should be 0")
 	require.EqualValues(t, -1, q.binarySearch(expiry1), "index should be -1")
 
 	// 2
-	expiry2 := time.Now()
-	_ = q.insert(&goWorker{lastUsed: time.Now()})
+	currTime++
+	expiry2 := currTime
+	currTime++
+	_ = q.insert(&goWorker{lastUsed: currTime})
 
 	require.EqualValues(t, -1, q.binarySearch(expiry1), "index should be -1")
 
 	require.EqualValues(t, 0, q.binarySearch(expiry2), "index should be 0")
 
-	require.EqualValues(t, 1, q.binarySearch(time.Now()), "index should be 1")
+	require.EqualValues(t, 1, q.binarySearch(currTime), "index should be 1")
 
 	// more
 	for i := 0; i < 5; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		currTime++
+		_ = q.insert(&goWorker{lastUsed: currTime})
 	}
 
-	expiry3 := time.Now()
+	currTime++
+	expiry3 := currTime
 	_ = q.insert(&goWorker{lastUsed: expiry3})
 
 	var err error
 	for err != errQueueIsFull {
-		err = q.insert(&goWorker{lastUsed: time.Now()})
+		currTime++
+		err = q.insert(&goWorker{lastUsed: currTime})
 	}
 
 	require.EqualValues(t, 7, q.binarySearch(expiry3), "index should be 7")
@@ -117,11 +124,13 @@ func TestRotatedQueueSearch(t *testing.T) {
 		_ = q.detach()
 	}
 
-	expiry4 := time.Now()
+	currTime++
+	expiry4 := currTime
 	_ = q.insert(&goWorker{lastUsed: expiry4})
 
 	for i := 0; i < 4; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		currTime++
+		_ = q.insert(&goWorker{lastUsed: currTime})
 	}
 	//	head = 6, tail = 5, insert direction ->
 	// [expiry4, time, time, time,  time, nil/tail,  time/head, time, time, time]
@@ -130,7 +139,8 @@ func TestRotatedQueueSearch(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		_ = q.detach()
 	}
-	expiry5 := time.Now()
+	currTime++
+	expiry5 := currTime
 	_ = q.insert(&goWorker{lastUsed: expiry5})
 
 	//	head = 6, tail = 5, insert direction ->
@@ -138,14 +148,15 @@ func TestRotatedQueueSearch(t *testing.T) {
 	require.EqualValues(t, 5, q.binarySearch(expiry5), "index should be 5")
 
 	for i := 0; i < 3; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		currTime++
+		_ = q.insert(&goWorker{lastUsed: currTime})
 	}
 	//	head = 9, tail = 9, insert direction ->
 	// [expiry4, time, time, time,  time, expiry5,  time, time, time, time/head/tail]
 	require.EqualValues(t, -1, q.binarySearch(expiry2), "index should be -1")
 
 	require.EqualValues(t, 9, q.binarySearch(q.items[9].lastUsedTime()), "index should be 9")
-	require.EqualValues(t, 8, q.binarySearch(time.Now()), "index should be 8")
+	require.EqualValues(t, 8, q.binarySearch(currTime), "index should be 8")
 }
 
 func TestRetrieveExpiry(t *testing.T) {
@@ -156,13 +167,13 @@ func TestRetrieveExpiry(t *testing.T) {
 
 	// test [ time+1s, time+1s, time+1s, time+1s, time+1s, time, time, time, time, time]
 	for i := 0; i < size/2; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		_ = q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 	}
 	expirew = append(expirew, q.items[:size/2]...)
 	time.Sleep(u)
 
 	for i := 0; i < size/2; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		_ = q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 	}
 	workers := q.refresh(u)
 
@@ -172,7 +183,7 @@ func TestRetrieveExpiry(t *testing.T) {
 	time.Sleep(u)
 
 	for i := 0; i < size/2; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		_ = q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 	}
 	expirew = expirew[:0]
 	expirew = append(expirew, q.items[size/2:]...)
@@ -183,13 +194,13 @@ func TestRetrieveExpiry(t *testing.T) {
 
 	// test [ time+1s, time+1s, time+1s, nil, nil, time+1s, time+1s, time+1s, time+1s, time+1s]
 	for i := 0; i < size/2; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		_ = q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 	}
 	for i := 0; i < size/2; i++ {
 		_ = q.detach()
 	}
 	for i := 0; i < 3; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		_ = q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 	}
 	time.Sleep(u)
 

--- a/worker_queue.go
+++ b/worker_queue.go
@@ -33,8 +33,8 @@ var errQueueIsFull = errors.New("the queue is full")
 type worker interface {
 	run()
 	finish()
-	lastUsedTime() time.Time
-	setLastUsedTime(t time.Time)
+	lastUsedTime() int64
+	setLastUsedTime(t int64)
 	inputFunc(func())
 	inputArg(any)
 }

--- a/worker_stack.go
+++ b/worker_stack.go
@@ -67,7 +67,7 @@ func (ws *workerStack) refresh(duration time.Duration) []worker {
 		return nil
 	}
 
-	expiryTime := time.Now().Add(-duration)
+	expiryTime := time.Now().Add(-duration).UnixNano()
 	index := ws.binarySearch(0, n-1, expiryTime)
 
 	ws.expiry = ws.expiry[:0]
@@ -82,10 +82,10 @@ func (ws *workerStack) refresh(duration time.Duration) []worker {
 	return ws.expiry
 }
 
-func (ws *workerStack) binarySearch(l, r int, expiryTime time.Time) int {
+func (ws *workerStack) binarySearch(l, r int, expiryTime int64) int {
 	for l <= r {
 		mid := l + ((r - l) >> 1) // avoid overflow when computing mid
-		if expiryTime.Before(ws.items[mid].lastUsedTime()) {
+		if expiryTime < ws.items[mid].lastUsedTime() {
 			r = mid - 1
 		} else {
 			l = mid + 1

--- a/worker_stack_test.go
+++ b/worker_stack_test.go
@@ -42,14 +42,14 @@ func TestWorkerStack(t *testing.T) {
 	q := newWorkerQueue(queueType(-1), 0)
 
 	for i := 0; i < 5; i++ {
-		err := q.insert(&goWorker{lastUsed: time.Now()})
+		err := q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 		if err != nil {
 			break
 		}
 	}
 	require.EqualValues(t, 5, q.len(), "Len error")
 
-	expired := time.Now()
+	expired := time.Now().UnixNano()
 
 	err := q.insert(&goWorker{lastUsed: expired})
 	if err != nil {
@@ -59,7 +59,7 @@ func TestWorkerStack(t *testing.T) {
 	time.Sleep(time.Second)
 
 	for i := 0; i < 6; i++ {
-		err := q.insert(&goWorker{lastUsed: time.Now()})
+		err := q.insert(&goWorker{lastUsed: time.Now().UnixNano()})
 		if err != nil {
 			t.Fatal("Enqueue error")
 		}
@@ -78,35 +78,42 @@ func TestSearch(t *testing.T) {
 
 	q := newWorkerStack(0)
 
+	currTime := time.Now().UnixNano()
+
 	// 1
-	expiry1 := time.Now()
+	expiry1 := currTime
+	currTime++
+	_ = q.insert(&goWorker{lastUsed: currTime})
 
-	_ = q.insert(&goWorker{lastUsed: time.Now()})
-
-	require.EqualValues(t, 0, q.binarySearch(0, q.len()-1, time.Now()), "index should be 0")
+	require.EqualValues(t, 0, q.binarySearch(0, q.len()-1, currTime), "index should be 0")
 	require.EqualValues(t, -1, q.binarySearch(0, q.len()-1, expiry1), "index should be -1")
 
 	// 2
-	expiry2 := time.Now()
-	_ = q.insert(&goWorker{lastUsed: time.Now()})
+	currTime++
+	expiry2 := currTime
+	currTime++
+	_ = q.insert(&goWorker{lastUsed: currTime})
 
 	require.EqualValues(t, -1, q.binarySearch(0, q.len()-1, expiry1), "index should be -1")
 
 	require.EqualValues(t, 0, q.binarySearch(0, q.len()-1, expiry2), "index should be 0")
 
-	require.EqualValues(t, 1, q.binarySearch(0, q.len()-1, time.Now()), "index should be 1")
+	require.EqualValues(t, 1, q.binarySearch(0, q.len()-1, currTime), "index should be 1")
 
 	// more
 	for i := 0; i < 5; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		currTime++
+		_ = q.insert(&goWorker{lastUsed: currTime})
 	}
 
-	expiry3 := time.Now()
+	currTime++
+	expiry3 := currTime
 
 	_ = q.insert(&goWorker{lastUsed: expiry3})
 
 	for i := 0; i < 10; i++ {
-		_ = q.insert(&goWorker{lastUsed: time.Now()})
+		currTime++
+		_ = q.insert(&goWorker{lastUsed: currTime})
 	}
 
 	require.EqualValues(t, 7, q.binarySearch(0, q.len()-1, expiry3), "index should be 7")


### PR DESCRIPTION
<!--
Thank you for contributing to `ants`! Please fill this out to help us review your pull request more efficiently.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?

Optimizations.

## 2. Please describe how these code changes achieve your intention.

Worker management has been improved by changing both `lastUsed` and the cached pool time from `time.Time` to `int64`. Core operations such as worker expiry checks and binary search now work directly with `int64` values, avoiding unnecessary `time.Time` conversions and method calls. This change also reduces the `worker` struct size by **16 bytes**, improving CPU cache efficiency and lowering GC scan overhead.

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->
Aligned with the recent change to use Unix Nano timestamp for `now` in `poolCommon`.


## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [x] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
