### PR TITLE
docs: correct WithNonblocking comment about its returned error

### DIFF
--- a/options.go
+++ b/options.go
@@ -96,7 +96,7 @@ func WithMaxBlockingTasks(maxBlockingTasks int) Option {
 	}
 }
 
-// WithNonblocking indicates that pool will return nil when there is no available workers.
+// WithNonblocking indicates that pool will return ErrPoolOverload when there is no available workers.
 func WithNonblocking(nonblocking bool) Option {
 	return func(opts *Options) {
 		opts.Nonblocking = nonblocking


### PR DESCRIPTION
## What
Correct the comment of `WithNonblocking` option in `options.go`.

## Why
The original comment was misleading. The WithNonblocking option returns an error when the pool is full, not `nil`.

## Changes
- File: `options.go`
- Updated the comment to match the actual behavior.

## Risk
Zero risk, only comment change.