### PR TITLE
fix: use %w to wrap errors for proper errors.Is/As support

### DIFF
--- a/multipool.go
+++ b/multipool.go
@@ -57,7 +57,7 @@ func releasePools(ctx context.Context, pools []contextReleaser) error {
 			wg.Go(func() error {
 				err := p.ReleaseContext(ctx)
 				if err != nil {
-					err = fmt.Errorf("pool %d: %v", idx, err)
+					err = fmt.Errorf("pool %d: %w", idx, err)
 				}
 				errCh <- err
 				return err


### PR DESCRIPTION
## What
Change error wrapping from `%v` to `%w` in multipool.go.

## Why
Using `%w` allows callers to unwrap and check the original error with `errors.Is` and `errors.As`, which is the idiomatic way in Go 1.13+.

## Changes
- File: `multipool.go`
- Replaced `fmt.Errorf("pool %d: %v", idx, err)` with `fmt.Errorf("pool %d: %w", idx, err)`.

## Risk
Low risk, backward compatible.