### PR TITLE
chore: replace 1<<31-1 with math.MaxInt32

### DIFF
--- a/multipool.go
+++ b/multipool.go
@@ -120,7 +120,7 @@ func (mp *MultiPool) next(lbs LoadBalancingStrategy) (idx int) {
 	case RoundRobin:
 		return int(atomic.AddUint32(&mp.index, 1) % uint32(len(mp.pools)))
 	case LeastTasks:
-		leastTasks := 1<<31 - 1
+		leastTasks := math.MaxInt32
 		for i, pool := range mp.pools {
 			if n := pool.Running(); n < leastTasks {
 				leastTasks = n

--- a/multipool_func.go
+++ b/multipool_func.go
@@ -67,7 +67,7 @@ func (mp *MultiPoolWithFunc) next(lbs LoadBalancingStrategy) (idx int) {
 	case RoundRobin:
 		return int(atomic.AddUint32(&mp.index, 1) % uint32(len(mp.pools)))
 	case LeastTasks:
-		leastTasks := 1<<31 - 1
+		leastTasks := math.MaxInt32
 		for i, pool := range mp.pools {
 			if n := pool.Running(); n < leastTasks {
 				leastTasks = n

--- a/multipool_func_generic.go
+++ b/multipool_func_generic.go
@@ -63,7 +63,7 @@ func (mp *MultiPoolWithFuncGeneric[T]) next(lbs LoadBalancingStrategy) (idx int)
 	case RoundRobin:
 		return int(atomic.AddUint32(&mp.index, 1) % uint32(len(mp.pools)))
 	case LeastTasks:
-		leastTasks := 1<<31 - 1
+		leastTasks := math.MaxInt32
 		for i, pool := range mp.pools {
 			if n := pool.Running(); n < leastTasks {
 				leastTasks = n


### PR DESCRIPTION
## What
Replace magic number `1<<31 - 1` with `math.MaxInt32` in multipool-related files.

## Why
`1<<31 - 1` is equivalent to `math.MaxInt32` (2147483647). Using the standard library constant improves readability and makes the intent clearer.

## Changes
- File: `multipool.go`
- File: `multipool_func.go`
- File: `multipool_func_generic.go`
- Replaced all occurrences of `leastTasks := 1<<31 - 1` with `leastTasks := math.MaxInt32`.

## Risk
Zero risk, equivalent replacement.