### PR TITLE
chore: improve variable naming in binarySearch

### DIFF
--- a/worker_loop_queue.go
+++ b/worker_loop_queue.go
@@ -124,8 +124,7 @@ func (wq *loopQueue) refresh(duration time.Duration) []worker {
 }
 
 func (wq *loopQueue) binarySearch(expiryTime int64) int {
-	var mid, nlen, basel, tmid int
-	nlen = len(wq.items)
+	n := len(wq.items)
 
 	// if no need to remove work, return -1
 	if wq.isEmpty() || expiryTime < wq.items[wq.head].lastUsedTime() {
@@ -143,13 +142,13 @@ func (wq *loopQueue) binarySearch(expiryTime int64) int {
 
 	// base algorithm is a copy from worker_stack
 	// map head and tail to effective left and right
-	r := (wq.tail - 1 - wq.head + nlen) % nlen
-	basel = wq.head
+	r := (wq.tail - 1 - wq.head + n) % n
+	base := wq.head
 	l := 0
 	for l <= r {
-		mid = l + ((r - l) >> 1) // avoid overflow when computing mid
+		mid := l + ((r - l) >> 1) // avoid overflow when computing mid
 		// calculate true mid position from mapped mid position
-		tmid = (mid + basel + nlen) % nlen
+		tmid := (mid + base + n) % n
 		if expiryTime < wq.items[tmid].lastUsedTime() {
 			r = mid - 1
 		} else {
@@ -157,7 +156,7 @@ func (wq *loopQueue) binarySearch(expiryTime int64) int {
 		}
 	}
 	// return true position from mapped position
-	return (r + basel + nlen) % nlen
+	return (r + base + n) % n
 }
 
 func (wq *loopQueue) reset() {


### PR DESCRIPTION
## What
Refactored variable names in `binarySearch` for better readability, while keeping the original logic unchanged.

## Why
Original variable names like `nlen` and `basel` are less clear. Renaming them to `n` and `base` makes the binary search logic easier to follow, without changing any behavior.

## Changes
- File: `worker_loop_queue.go`
- Renamed variables in `binarySearch` and kept all comments intact.

## Risk
Zero risk, no logic change.