### PR TITLE
fix: release already created pools on NewMultiPool failure

### DIFF
--- a/multipool.go
+++ b/multipool.go
@@ -108,6 +108,10 @@ func NewMultiPool(size, sizePerPool int, lbs LoadBalancingStrategy, options ...O
 	for i := 0; i < size; i++ {
 		pool, err := NewPool(sizePerPool, options...)
 		if err != nil {
+			// Release all previously created pools to avoid resource leak
+			for j := 0; j < i; j++ {
+				pools[j].Release()
+			}
 			return nil, err
 		}
 		pools[i] = pool

--- a/multipool_func.go
+++ b/multipool_func.go
@@ -55,6 +55,10 @@ func NewMultiPoolWithFunc(size, sizePerPool int, fn func(any), lbs LoadBalancing
 	for i := 0; i < size; i++ {
 		pool, err := NewPoolWithFunc(sizePerPool, fn, options...)
 		if err != nil {
+			// Release all previously created pools to avoid resource leak
+			for j := 0; j < i; j++ {
+				pools[j].Release()
+			}
 			return nil, err
 		}
 		pools[i] = pool

--- a/multipool_func_generic.go
+++ b/multipool_func_generic.go
@@ -51,6 +51,10 @@ func NewMultiPoolWithFuncGeneric[T any](size, sizePerPool int, fn func(T), lbs L
 	for i := 0; i < size; i++ {
 		pool, err := NewPoolWithFuncGeneric(sizePerPool, fn, options...)
 		if err != nil {
+			// Release all previously created pools to avoid resource leak
+			for j := 0; j < i; j++ {
+				pools[j].Release()
+			}
 			return nil, err
 		}
 		pools[i] = pool


### PR DESCRIPTION
## What
Added cleanup logic to release pools if `NewMultiPool` fails halfway.

## Why
If creating a sub-pool fails in the middle of the loop, the already created pools were not released, leading to resource leaks.

## Changes
- File: `multipool.go`
- File: `multipool_func.go`
- File: `multipool_func_generic.go`
- Added a loop to call `Release()` on all previously created pools when an error occurs.

## Risk
Low risk, only adds cleanup logic.