### PR TITLE
Feat/multipool loadbalancer interface

### DIFF
--- a/ants_benchmark_test.go
+++ b/ants_benchmark_test.go
@@ -23,6 +23,7 @@
 package ants_test
 
 import (
+	"math/rand"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -225,4 +226,159 @@ func BenchmarkParallelAntsMultiPoolThroughput(b *testing.B) {
 			_ = p.Submit(demoFunc)
 		}
 	})
+}
+
+// cpuTask simulates a CPU-intensive task.
+func cpuTask() {
+	n := 0
+	for i := 0; i < 1000; i++ {
+		n += i * i
+	}
+	_ = n
+}
+
+// ioTask simulates an IO-intensive task with a short sleep.
+func ioTask() {
+	time.Sleep(time.Millisecond)
+}
+
+// mixedTask simulates uneven task durations to stress load-balancing decisions.
+func mixedTask() {
+	if time.Now().UnixNano()%5 == 0 {
+		time.Sleep(10 * time.Millisecond)
+	} else {
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func benchmarkMultiPoolLBS(b *testing.B, lb ants.LoadBalancer, task func()) {
+	p, _ := ants.NewMultiPoolWithLB(10, PoolCap/10, lb, ants.WithExpiryDuration(DefaultExpiredTime))
+	defer p.ReleaseTimeout(DefaultExpiredTime) //nolint:errcheck
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = p.Submit(task)
+		}
+	})
+}
+
+// CPU-intensive task benchmarks across LBS strategies.
+
+func BenchmarkMultiPool_RoundRobin_CPUThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, ants.NewRoundRobinLB(), cpuTask)
+}
+
+func BenchmarkMultiPool_LeastTasks_CPUThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, ants.NewLeastTasksLB(), cpuTask)
+}
+
+func BenchmarkMultiPool_LeastWaiting_CPUThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, ants.NewLeastWaitingLB(), cpuTask)
+}
+
+// IO-intensive task benchmarks across LBS strategies.
+
+func BenchmarkMultiPool_RoundRobin_IOThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, ants.NewRoundRobinLB(), ioTask)
+}
+
+func BenchmarkMultiPool_LeastTasks_IOThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, ants.NewLeastTasksLB(), ioTask)
+}
+
+func BenchmarkMultiPool_LeastWaiting_IOThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, ants.NewLeastWaitingLB(), ioTask)
+}
+
+// Mixed (uneven duration) task benchmarks across LBS strategies.
+
+func BenchmarkMultiPool_RoundRobin_MixedThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, ants.NewRoundRobinLB(), mixedTask)
+}
+
+func BenchmarkMultiPool_LeastTasks_MixedThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, ants.NewLeastTasksLB(), mixedTask)
+}
+
+func BenchmarkMultiPool_LeastWaiting_MixedThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, ants.NewLeastWaitingLB(), mixedTask)
+}
+
+// randomLB is a custom LoadBalancer that picks a pool at random,
+// demonstrating how users can plug in their own strategy via NewMultiPoolWithLB.
+type randomLB struct{}
+
+func newRandomLB() *randomLB {
+	return &randomLB{}
+}
+
+func (r *randomLB) Pick(pools []ants.PoolMetrics) int {
+	return rand.Intn(len(pools))
+}
+
+func (r *randomLB) Fallback(pools []ants.PoolMetrics) int {
+	return -1
+}
+
+// Custom random LB benchmarks across task types.
+
+func BenchmarkMultiPool_Random_CPUThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, newRandomLB(), cpuTask)
+}
+
+func BenchmarkMultiPool_Random_IOThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, newRandomLB(), ioTask)
+}
+
+func BenchmarkMultiPool_Random_MixedThroughput(b *testing.B) {
+	benchmarkMultiPoolLBS(b, newRandomLB(), mixedTask)
+}
+
+func benchmarkMultiPoolWithFuncLBSThroughput(b *testing.B, lb ants.LoadBalancer) {
+	p, _ := ants.NewMultiPoolWithFuncAndLB(10, PoolCap/10, demoPoolFunc, lb, ants.WithExpiryDuration(DefaultExpiredTime))
+	defer p.ReleaseTimeout(DefaultExpiredTime) //nolint:errcheck
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = p.Invoke(BenchParam)
+		}
+	})
+}
+
+func BenchmarkMultiPoolWithFunc_RoundRobin_Throughput(b *testing.B) {
+	benchmarkMultiPoolWithFuncLBSThroughput(b, ants.NewRoundRobinLB())
+}
+
+func BenchmarkMultiPoolWithFunc_LeastTasks_Throughput(b *testing.B) {
+	benchmarkMultiPoolWithFuncLBSThroughput(b, ants.NewLeastTasksLB())
+}
+
+func BenchmarkMultiPoolWithFunc_LeastWaiting_Throughput(b *testing.B) {
+	benchmarkMultiPoolWithFuncLBSThroughput(b, ants.NewLeastWaitingLB())
+}
+
+func benchmarkMultiPoolWithFuncGenericLBSThroughput(b *testing.B, lb ants.LoadBalancer) {
+	p, _ := ants.NewMultiPoolWithFuncGenericAndLB(10, PoolCap/10, demoPoolFuncInt, lb, ants.WithExpiryDuration(DefaultExpiredTime))
+	defer p.ReleaseTimeout(DefaultExpiredTime) //nolint:errcheck
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = p.Invoke(BenchParam)
+		}
+	})
+}
+
+func BenchmarkMultiPoolWithFuncGeneric_RoundRobin_Throughput(b *testing.B) {
+	benchmarkMultiPoolWithFuncGenericLBSThroughput(b, ants.NewRoundRobinLB())
+}
+
+func BenchmarkMultiPoolWithFuncGeneric_LeastTasks_Throughput(b *testing.B) {
+	benchmarkMultiPoolWithFuncGenericLBSThroughput(b, ants.NewLeastTasksLB())
+}
+
+func BenchmarkMultiPoolWithFuncGeneric_LeastWaiting_Throughput(b *testing.B) {
+	benchmarkMultiPoolWithFuncGenericLBSThroughput(b, ants.NewLeastWaitingLB())
 }

--- a/ants_benchmark_test.go
+++ b/ants_benchmark_test.go
@@ -317,7 +317,7 @@ func (r *randomLB) Pick(pools []ants.PoolMetrics) int {
 	return rand.Intn(len(pools))
 }
 
-func (r *randomLB) Fallback(pools []ants.PoolMetrics) int {
+func (r *randomLB) FallBack(_ []ants.PoolMetrics) int {
 	return -1
 }
 

--- a/ants_test.go
+++ b/ants_test.go
@@ -1815,6 +1815,7 @@ func TestRebootNewPoolWithPreAllocCalc(t *testing.T) {
 	wg.Wait()
 	require.EqualValues(t, 499500, sum, "The result should be 499500")
 }
+
 func TestMultiPoolWithLB_RoundRobin(t *testing.T) {
 	_, err := ants.NewMultiPoolWithLB(-1, 5, ants.NewRoundRobinLB())
 	require.ErrorIs(t, err, ants.ErrInvalidMultiPoolSize)

--- a/ants_test.go
+++ b/ants_test.go
@@ -1815,3 +1815,212 @@ func TestRebootNewPoolWithPreAllocCalc(t *testing.T) {
 	wg.Wait()
 	require.EqualValues(t, 499500, sum, "The result should be 499500")
 }
+func TestMultiPoolWithLB_RoundRobin(t *testing.T) {
+	_, err := ants.NewMultiPoolWithLB(-1, 5, ants.NewRoundRobinLB())
+	require.ErrorIs(t, err, ants.ErrInvalidMultiPoolSize)
+	_, err = ants.NewMultiPoolWithLB(10, 5, nil)
+	require.ErrorIs(t, err, ants.ErrInvalidLoadBalancingStrategy)
+	_, err = ants.NewMultiPoolWithLB(10, 5, ants.NewRoundRobinLB(), ants.WithExpiryDuration(-1))
+	require.ErrorIs(t, err, ants.ErrInvalidPoolExpiry)
+
+	mp, err := ants.NewMultiPoolWithLB(10, 5, ants.NewRoundRobinLB())
+	require.NoError(t, err)
+	testFn := func() {
+		for i := 0; i < 50; i++ {
+			err = mp.Submit(longRunningFunc)
+			require.NoError(t, err)
+		}
+		require.EqualValues(t, 50, mp.Running())
+		require.EqualValues(t, 50, mp.Cap())
+		require.EqualValues(t, 0, mp.Free())
+		require.False(t, mp.IsClosed())
+		atomic.StoreInt32(&stopLongRunningFunc, 1)
+		require.NoError(t, mp.ReleaseTimeout(3*time.Second))
+		require.ErrorIs(t, mp.Submit(nil), ants.ErrPoolClosed)
+		require.True(t, mp.IsClosed())
+		atomic.StoreInt32(&stopLongRunningFunc, 0)
+	}
+	testFn()
+	mp.Reboot()
+	testFn()
+}
+
+func TestMultiPoolWithLB_LeastTasks(t *testing.T) {
+	mp, err := ants.NewMultiPoolWithLB(10, 5, ants.NewLeastTasksLB(), ants.WithNonblocking(true))
+	require.NoError(t, err)
+	testFn := func() {
+		for i := 0; i < 50; i++ {
+			_ = mp.Submit(longRunningFunc)
+		}
+		require.False(t, mp.IsClosed())
+		atomic.StoreInt32(&stopLongRunningFunc, 1)
+		require.NoError(t, mp.ReleaseTimeout(3*time.Second))
+		require.ErrorIs(t, mp.Submit(nil), ants.ErrPoolClosed)
+		require.True(t, mp.IsClosed())
+		atomic.StoreInt32(&stopLongRunningFunc, 0)
+	}
+	testFn()
+	mp.Reboot()
+	testFn()
+}
+
+func TestMultiPoolWithLB_LeastWaiting(t *testing.T) {
+	mp, err := ants.NewMultiPoolWithLB(10, 5, ants.NewLeastWaitingLB(), ants.WithNonblocking(true))
+	require.NoError(t, err)
+	testFn := func() {
+		for i := 0; i < 50; i++ {
+			_ = mp.Submit(longRunningFunc)
+		}
+		require.False(t, mp.IsClosed())
+		atomic.StoreInt32(&stopLongRunningFunc, 1)
+		require.NoError(t, mp.ReleaseTimeout(3*time.Second))
+		require.ErrorIs(t, mp.Submit(nil), ants.ErrPoolClosed)
+		require.True(t, mp.IsClosed())
+		atomic.StoreInt32(&stopLongRunningFunc, 0)
+	}
+	testFn()
+	mp.Reboot()
+	testFn()
+}
+
+func TestMultiPoolWithFuncAndLB_RoundRobin(t *testing.T) {
+	_, err := ants.NewMultiPoolWithFuncAndLB(-1, 5, longRunningPoolFunc, ants.NewRoundRobinLB())
+	require.ErrorIs(t, err, ants.ErrInvalidMultiPoolSize)
+	_, err = ants.NewMultiPoolWithFuncAndLB(10, 5, longRunningPoolFunc, nil)
+	require.ErrorIs(t, err, ants.ErrInvalidLoadBalancingStrategy)
+	_, err = ants.NewMultiPoolWithFuncAndLB(10, 5, longRunningPoolFunc, ants.NewRoundRobinLB(), ants.WithExpiryDuration(-1))
+	require.ErrorIs(t, err, ants.ErrInvalidPoolExpiry)
+
+	ch := make(chan struct{})
+	mp, err := ants.NewMultiPoolWithFuncAndLB(10, 5, longRunningPoolFunc, ants.NewRoundRobinLB())
+	require.NoError(t, err)
+	testFn := func() {
+		for i := 0; i < 50; i++ {
+			err = mp.Invoke(ch)
+			require.NoError(t, err)
+		}
+		require.EqualValues(t, 50, mp.Running())
+		require.EqualValues(t, 50, mp.Cap())
+		require.EqualValues(t, 0, mp.Free())
+		require.False(t, mp.IsClosed())
+		close(ch)
+		require.NoError(t, mp.ReleaseTimeout(3*time.Second))
+		require.ErrorIs(t, mp.Invoke(nil), ants.ErrPoolClosed)
+		require.True(t, mp.IsClosed())
+		ch = make(chan struct{})
+	}
+	testFn()
+	mp.Reboot()
+	testFn()
+}
+
+func TestMultiPoolWithFuncAndLB_LeastTasks(t *testing.T) {
+	ch := make(chan struct{})
+	mp, err := ants.NewMultiPoolWithFuncAndLB(10, 5, longRunningPoolFunc, ants.NewLeastTasksLB(), ants.WithNonblocking(true))
+	require.NoError(t, err)
+	testFn := func() {
+		for i := 0; i < 50; i++ {
+			_ = mp.Invoke(ch)
+		}
+		require.False(t, mp.IsClosed())
+		close(ch)
+		require.NoError(t, mp.ReleaseTimeout(3*time.Second))
+		require.ErrorIs(t, mp.Invoke(nil), ants.ErrPoolClosed)
+		require.True(t, mp.IsClosed())
+		ch = make(chan struct{})
+	}
+	testFn()
+	mp.Reboot()
+	testFn()
+}
+
+func TestMultiPoolWithFuncAndLB_LeastWaiting(t *testing.T) {
+	ch := make(chan struct{})
+	mp, err := ants.NewMultiPoolWithFuncAndLB(10, 5, longRunningPoolFunc, ants.NewLeastWaitingLB(), ants.WithNonblocking(true))
+	require.NoError(t, err)
+	testFn := func() {
+		for i := 0; i < 50; i++ {
+			_ = mp.Invoke(ch)
+		}
+		require.False(t, mp.IsClosed())
+		close(ch)
+		require.NoError(t, mp.ReleaseTimeout(3*time.Second))
+		require.ErrorIs(t, mp.Invoke(nil), ants.ErrPoolClosed)
+		require.True(t, mp.IsClosed())
+		ch = make(chan struct{})
+	}
+	testFn()
+	mp.Reboot()
+	testFn()
+}
+
+func TestMultiPoolWithFuncGenericAndLB_RoundRobin(t *testing.T) {
+	_, err := ants.NewMultiPoolWithFuncGenericAndLB(-1, 5, longRunningPoolFuncCh, ants.NewRoundRobinLB())
+	require.ErrorIs(t, err, ants.ErrInvalidMultiPoolSize)
+	_, err = ants.NewMultiPoolWithFuncGenericAndLB(10, 5, longRunningPoolFuncCh, nil)
+	require.ErrorIs(t, err, ants.ErrInvalidLoadBalancingStrategy)
+	_, err = ants.NewMultiPoolWithFuncGenericAndLB(10, 5, longRunningPoolFuncCh, ants.NewRoundRobinLB(), ants.WithExpiryDuration(-1))
+	require.ErrorIs(t, err, ants.ErrInvalidPoolExpiry)
+
+	ch := make(chan struct{})
+	mp, err := ants.NewMultiPoolWithFuncGenericAndLB(10, 5, longRunningPoolFuncCh, ants.NewRoundRobinLB())
+	require.NoError(t, err)
+	testFn := func() {
+		for i := 0; i < 50; i++ {
+			err = mp.Invoke(ch)
+			require.NoError(t, err)
+		}
+		require.EqualValues(t, 50, mp.Running())
+		require.EqualValues(t, 50, mp.Cap())
+		require.EqualValues(t, 0, mp.Free())
+		require.False(t, mp.IsClosed())
+		close(ch)
+		require.NoError(t, mp.ReleaseTimeout(3*time.Second))
+		require.ErrorIs(t, mp.Invoke(nil), ants.ErrPoolClosed)
+		require.True(t, mp.IsClosed())
+		ch = make(chan struct{})
+	}
+	testFn()
+	mp.Reboot()
+	testFn()
+}
+
+func TestMultiPoolWithFuncGenericAndLB_LeastTasks(t *testing.T) {
+	ch := make(chan struct{})
+	mp, err := ants.NewMultiPoolWithFuncGenericAndLB(10, 5, longRunningPoolFuncCh, ants.NewLeastTasksLB(), ants.WithNonblocking(true))
+	require.NoError(t, err)
+	testFn := func() {
+		for i := 0; i < 50; i++ {
+			_ = mp.Invoke(ch)
+		}
+		require.False(t, mp.IsClosed())
+		close(ch)
+		require.NoError(t, mp.ReleaseTimeout(3*time.Second))
+		require.ErrorIs(t, mp.Invoke(nil), ants.ErrPoolClosed)
+		require.True(t, mp.IsClosed())
+		ch = make(chan struct{})
+	}
+	testFn()
+	mp.Reboot()
+	testFn()
+}
+
+func TestMultiPoolWithFuncGenericAndLB_LeastWaiting(t *testing.T) {
+	ch := make(chan struct{})
+	mp, err := ants.NewMultiPoolWithFuncGenericAndLB(10, 5, longRunningPoolFuncCh, ants.NewLeastWaitingLB(), ants.WithNonblocking(true))
+	require.NoError(t, err)
+	testFn := func() {
+		for i := 0; i < 50; i++ {
+			_ = mp.Invoke(ch)
+		}
+		require.False(t, mp.IsClosed())
+		close(ch)
+		require.NoError(t, mp.ReleaseTimeout(3*time.Second))
+		require.ErrorIs(t, mp.Invoke(nil), ants.ErrPoolClosed)
+		require.True(t, mp.IsClosed())
+		ch = make(chan struct{})
+	}
+	testFn()
+	mp.Reboot()
+	testFn()
+}

--- a/lbs.go
+++ b/lbs.go
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2023 Andy Pan
+// Copyright (c) 2026. Ants Authors. All rights reserved.
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -49,9 +49,9 @@ type PoolMetrics interface {
 // LoadBalancer picks a pool index from a slice of PoolMetrics.
 type LoadBalancer interface {
 	Pick(pools []PoolMetrics) int
-	// Fallback is called when the pool chosen by Pick is overloaded.
+	// FallBack is called when the pool chosen by Pick is overloaded.
 	// Return -1 to indicate no fallback is supported.
-	Fallback(pools []PoolMetrics) int
+	FallBack(pools []PoolMetrics) int
 }
 
 // roundRobinLB distributes tasks across pools in rotation.
@@ -68,7 +68,7 @@ func (r *roundRobinLB) Pick(pools []PoolMetrics) int {
 	return int(atomic.AddUint32(&r.index, 1) % uint32(len(pools)))
 }
 
-func (r *roundRobinLB) Fallback(pools []PoolMetrics) int {
+func (r *roundRobinLB) FallBack(pools []PoolMetrics) int {
 	return leastTasksPick(pools)
 }
 
@@ -95,7 +95,7 @@ func (l *leastTasksLB) Pick(pools []PoolMetrics) int {
 	return leastTasksPick(pools)
 }
 
-func (l *leastTasksLB) Fallback(pools []PoolMetrics) int {
+func (l *leastTasksLB) FallBack(_ []PoolMetrics) int {
 	return -1
 }
 
@@ -118,7 +118,7 @@ func (l *leastWaiting) Pick(pools []PoolMetrics) int {
 	return idx
 }
 
-func (l *leastWaiting) Fallback(pools []PoolMetrics) int {
+func (l *leastWaiting) FallBack(_ []PoolMetrics) int {
 	return -1
 }
 

--- a/lbs.go
+++ b/lbs.go
@@ -122,6 +122,11 @@ func (l *leastWaiting) Fallback(pools []PoolMetrics) int {
 	return -1
 }
 
+// validIdx checks that idx returned by a LoadBalancer is within bounds.
+func validIdx(idx, n int) bool {
+	return idx >= 0 && idx < n
+}
+
 func newBuiltinLB(lbs LoadBalancingStrategy) (LoadBalancer, error) {
 	switch lbs {
 	case RoundRobin:

--- a/lbs.go
+++ b/lbs.go
@@ -1,0 +1,133 @@
+// MIT License
+
+// Copyright (c) 2023 Andy Pan
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package ants
+
+import (
+	"math"
+	"sync/atomic"
+)
+
+// LoadBalancingStrategy represents the type of load-balancing algorithm.
+type LoadBalancingStrategy int
+
+const (
+	// RoundRobin distributes task to a list of pools in rotation.
+	RoundRobin LoadBalancingStrategy = 1 << (iota + 1)
+
+	// LeastTasks always selects the pool with the least number of pending tasks.
+	LeastTasks
+)
+
+// PoolMetrics exposes the read-only stats a LoadBalancer needs to make a pick decision.
+type PoolMetrics interface {
+	Running() int
+	Waiting() int
+	Free() int
+	Cap() int
+}
+
+// LoadBalancer picks a pool index from a slice of PoolMetrics.
+type LoadBalancer interface {
+	Pick(pools []PoolMetrics) int
+	// Fallback is called when the pool chosen by Pick is overloaded.
+	// Return -1 to indicate no fallback is supported.
+	Fallback(pools []PoolMetrics) int
+}
+
+// roundRobinLB distributes tasks across pools in rotation.
+type roundRobinLB struct {
+	index uint32
+}
+
+// NewRoundRobinLB returns a RoundRobin load balancer.
+func NewRoundRobinLB() LoadBalancer {
+	return &roundRobinLB{index: math.MaxUint32}
+}
+
+func (r *roundRobinLB) Pick(pools []PoolMetrics) int {
+	return int(atomic.AddUint32(&r.index, 1) % uint32(len(pools)))
+}
+
+func (r *roundRobinLB) Fallback(pools []PoolMetrics) int {
+	return leastTasksPick(pools)
+}
+
+func leastTasksPick(pools []PoolMetrics) int {
+	idx, least := 0, math.MaxInt32
+	for i, p := range pools {
+		if n := p.Running(); n < least {
+			least = n
+			idx = i
+		}
+	}
+	return idx
+}
+
+// leastTasksLB picks the pool with the fewest running tasks.
+type leastTasksLB struct{}
+
+// NewLeastTasksLB returns a LeastTasks load balancer.
+func NewLeastTasksLB() LoadBalancer {
+	return &leastTasksLB{}
+}
+
+func (l *leastTasksLB) Pick(pools []PoolMetrics) int {
+	return leastTasksPick(pools)
+}
+
+func (l *leastTasksLB) Fallback(pools []PoolMetrics) int {
+	return -1
+}
+
+// leastWaiting picks the pool with the fewest waiting tasks.
+type leastWaiting struct{}
+
+// NewLeastWaitingLB returns a LeastWaiting load balancer.
+func NewLeastWaitingLB() LoadBalancer {
+	return &leastWaiting{}
+}
+
+func (l *leastWaiting) Pick(pools []PoolMetrics) int {
+	idx, least := 0, math.MaxInt32
+	for i, p := range pools {
+		if n := p.Waiting(); n < least {
+			least = n
+			idx = i
+		}
+	}
+	return idx
+}
+
+func (l *leastWaiting) Fallback(pools []PoolMetrics) int {
+	return -1
+}
+
+func newBuiltinLB(lbs LoadBalancingStrategy) (LoadBalancer, error) {
+	switch lbs {
+	case RoundRobin:
+		return NewRoundRobinLB(), nil
+	case LeastTasks:
+		return NewLeastTasksLB(), nil
+	}
+	return nil, ErrInvalidLoadBalancingStrategy
+}

--- a/multipool.go
+++ b/multipool.go
@@ -133,7 +133,7 @@ func (mp *MultiPool) Submit(task func()) (err error) {
 		return ErrInvalidPoolIndex
 	}
 	if err = mp.pools[idx].Submit(task); err == ErrPoolOverload {
-		if fb := mp.lb.Fallback(mp.metrics); validIdx(fb, len(mp.pools)) {
+		if fb := mp.lb.FallBack(mp.metrics); validIdx(fb, len(mp.pools)) {
 			return mp.pools[fb].Submit(task)
 		}
 	}

--- a/multipool.go
+++ b/multipool.go
@@ -129,8 +129,11 @@ func (mp *MultiPool) Submit(task func()) (err error) {
 	}
 
 	idx := mp.lb.Pick(mp.metrics)
+	if !validIdx(idx, len(mp.pools)) {
+		return ErrInvalidPoolIndex
+	}
 	if err = mp.pools[idx].Submit(task); err == ErrPoolOverload {
-		if fb := mp.lb.Fallback(mp.metrics); fb >= 0 {
+		if fb := mp.lb.Fallback(mp.metrics); validIdx(fb, len(mp.pools)) {
 			return mp.pools[fb].Submit(task)
 		}
 	}

--- a/multipool.go
+++ b/multipool.go
@@ -26,23 +26,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
-)
-
-// LoadBalancingStrategy represents the type of load-balancing algorithm.
-type LoadBalancingStrategy int
-
-const (
-	// RoundRobin distributes task to a list of pools in rotation.
-	RoundRobin LoadBalancingStrategy = 1 << (iota + 1)
-
-	// LeastTasks always selects the pool with the least number of pending tasks.
-	LeastTasks
 )
 
 type contextReleaser interface {
@@ -88,10 +76,10 @@ func releasePools(ctx context.Context, pools []contextReleaser) error {
 // MultiPool is a good fit for the scenario where you have a large number of
 // tasks to submit, and you don't want the single pool to be the bottleneck.
 type MultiPool struct {
-	pools []*Pool
-	index uint32
-	state int32
-	lbs   LoadBalancingStrategy
+	pools   []*Pool
+	metrics []PoolMetrics
+	lb      LoadBalancer
+	state   int32
 }
 
 // NewMultiPool instantiates a MultiPool with a size of the pool list and a size
@@ -100,11 +88,24 @@ func NewMultiPool(size, sizePerPool int, lbs LoadBalancingStrategy, options ...O
 	if size <= 0 {
 		return nil, ErrInvalidMultiPoolSize
 	}
+	lb, err := newBuiltinLB(lbs)
+	if err != nil {
+		return nil, err
+	}
+	return NewMultiPoolWithLB(size, sizePerPool, lb, options...)
+}
 
-	if lbs != RoundRobin && lbs != LeastTasks {
+// NewMultiPoolWithLB instantiates a MultiPool with a given LoadBalancer.
+func NewMultiPoolWithLB(size, sizePerPool int, lb LoadBalancer, options ...Option) (*MultiPool, error) {
+	if size <= 0 {
+		return nil, ErrInvalidMultiPoolSize
+	}
+	if lb == nil {
 		return nil, ErrInvalidLoadBalancingStrategy
 	}
+
 	pools := make([]*Pool, size)
+	metrics := make([]PoolMetrics, size)
 	for i := 0; i < size; i++ {
 		pool, err := NewPool(sizePerPool, options...)
 		if err != nil {
@@ -115,25 +116,10 @@ func NewMultiPool(size, sizePerPool int, lbs LoadBalancingStrategy, options ...O
 			return nil, err
 		}
 		pools[i] = pool
+		metrics[i] = pool
 	}
-	return &MultiPool{pools: pools, index: math.MaxUint32, lbs: lbs}, nil
-}
 
-func (mp *MultiPool) next(lbs LoadBalancingStrategy) (idx int) {
-	switch lbs {
-	case RoundRobin:
-		return int(atomic.AddUint32(&mp.index, 1) % uint32(len(mp.pools)))
-	case LeastTasks:
-		leastTasks := math.MaxInt32
-		for i, pool := range mp.pools {
-			if n := pool.Running(); n < leastTasks {
-				leastTasks = n
-				idx = i
-			}
-		}
-		return
-	}
-	return -1
+	return &MultiPool{pools: pools, metrics: metrics, lb: lb}, nil
 }
 
 // Submit submits a task to a pool selected by the load-balancing strategy.
@@ -141,11 +127,12 @@ func (mp *MultiPool) Submit(task func()) (err error) {
 	if mp.IsClosed() {
 		return ErrPoolClosed
 	}
-	if err = mp.pools[mp.next(mp.lbs)].Submit(task); err == nil {
-		return
-	}
-	if err == ErrPoolOverload && mp.lbs == RoundRobin {
-		return mp.pools[mp.next(LeastTasks)].Submit(task)
+
+	idx := mp.lb.Pick(mp.metrics)
+	if err = mp.pools[idx].Submit(task); err == ErrPoolOverload {
+		if fb := mp.lb.Fallback(mp.metrics); fb >= 0 {
+			return mp.pools[fb].Submit(task)
+		}
 	}
 	return
 }
@@ -246,7 +233,6 @@ func (mp *MultiPool) ReleaseContext(ctx context.Context) error {
 // Reboot reboots a released multi-pool.
 func (mp *MultiPool) Reboot() {
 	if atomic.CompareAndSwapInt32(&mp.state, CLOSED, OPENED) {
-		atomic.StoreUint32(&mp.index, 0)
 		for _, pool := range mp.pools {
 			pool.Reboot()
 		}

--- a/multipool_func.go
+++ b/multipool_func.go
@@ -24,7 +24,6 @@ package ants
 
 import (
 	"context"
-	"math"
 	"sync/atomic"
 	"time"
 )
@@ -35,10 +34,10 @@ import (
 // MultiPoolWithFunc is a good fit for the scenario where you have a large number of
 // tasks to submit, and you don't want the single pool to be the bottleneck.
 type MultiPoolWithFunc struct {
-	pools []*PoolWithFunc
-	index uint32
-	state int32
-	lbs   LoadBalancingStrategy
+	pools   []*PoolWithFunc
+	metrics []PoolMetrics
+	lb      LoadBalancer
+	state   int32
 }
 
 // NewMultiPoolWithFunc instantiates a MultiPoolWithFunc with a size of the pool list and a size
@@ -47,11 +46,24 @@ func NewMultiPoolWithFunc(size, sizePerPool int, fn func(any), lbs LoadBalancing
 	if size <= 0 {
 		return nil, ErrInvalidMultiPoolSize
 	}
+	lb, err := newBuiltinLB(lbs)
+	if err != nil {
+		return nil, err
+	}
+	return NewMultiPoolWithFuncAndLB(size, sizePerPool, fn, lb, options...)
+}
 
-	if lbs != RoundRobin && lbs != LeastTasks {
+// NewMultiPoolWithFuncAndLB instantiates a MultiPoolWithFunc with a given LoadBalancer.
+func NewMultiPoolWithFuncAndLB(size, sizePerPool int, fn func(any), lb LoadBalancer, options ...Option) (*MultiPoolWithFunc, error) {
+	if size <= 0 {
+		return nil, ErrInvalidMultiPoolSize
+	}
+	if lb == nil {
 		return nil, ErrInvalidLoadBalancingStrategy
 	}
+
 	pools := make([]*PoolWithFunc, size)
+	metrics := make([]PoolMetrics, size)
 	for i := 0; i < size; i++ {
 		pool, err := NewPoolWithFunc(sizePerPool, fn, options...)
 		if err != nil {
@@ -62,25 +74,10 @@ func NewMultiPoolWithFunc(size, sizePerPool int, fn func(any), lbs LoadBalancing
 			return nil, err
 		}
 		pools[i] = pool
+		metrics[i] = pool
 	}
-	return &MultiPoolWithFunc{pools: pools, index: math.MaxUint32, lbs: lbs}, nil
-}
 
-func (mp *MultiPoolWithFunc) next(lbs LoadBalancingStrategy) (idx int) {
-	switch lbs {
-	case RoundRobin:
-		return int(atomic.AddUint32(&mp.index, 1) % uint32(len(mp.pools)))
-	case LeastTasks:
-		leastTasks := math.MaxInt32
-		for i, pool := range mp.pools {
-			if n := pool.Running(); n < leastTasks {
-				leastTasks = n
-				idx = i
-			}
-		}
-		return
-	}
-	return -1
+	return &MultiPoolWithFunc{pools: pools, metrics: metrics, lb: lb}, nil
 }
 
 // Invoke submits a task to a pool selected by the load-balancing strategy.
@@ -88,12 +85,11 @@ func (mp *MultiPoolWithFunc) Invoke(args any) (err error) {
 	if mp.IsClosed() {
 		return ErrPoolClosed
 	}
-
-	if err = mp.pools[mp.next(mp.lbs)].Invoke(args); err == nil {
-		return
-	}
-	if err == ErrPoolOverload && mp.lbs == RoundRobin {
-		return mp.pools[mp.next(LeastTasks)].Invoke(args)
+	idx := mp.lb.Pick(mp.metrics)
+	if err = mp.pools[idx].Invoke(args); err == ErrPoolOverload {
+		if fb := mp.lb.Fallback(mp.metrics); fb >= 0 {
+			return mp.pools[fb].Invoke(args)
+		}
 	}
 	return
 }
@@ -194,7 +190,6 @@ func (mp *MultiPoolWithFunc) ReleaseContext(ctx context.Context) error {
 // Reboot reboots a released multi-pool.
 func (mp *MultiPoolWithFunc) Reboot() {
 	if atomic.CompareAndSwapInt32(&mp.state, CLOSED, OPENED) {
-		atomic.StoreUint32(&mp.index, 0)
 		for _, pool := range mp.pools {
 			pool.Reboot()
 		}

--- a/multipool_func.go
+++ b/multipool_func.go
@@ -90,7 +90,7 @@ func (mp *MultiPoolWithFunc) Invoke(args any) (err error) {
 		return ErrInvalidPoolIndex
 	}
 	if err = mp.pools[idx].Invoke(args); err == ErrPoolOverload {
-		if fb := mp.lb.Fallback(mp.metrics); validIdx(fb, len(mp.pools)) {
+		if fb := mp.lb.FallBack(mp.metrics); validIdx(fb, len(mp.pools)) {
 			return mp.pools[fb].Invoke(args)
 		}
 	}

--- a/multipool_func.go
+++ b/multipool_func.go
@@ -86,8 +86,11 @@ func (mp *MultiPoolWithFunc) Invoke(args any) (err error) {
 		return ErrPoolClosed
 	}
 	idx := mp.lb.Pick(mp.metrics)
+	if !validIdx(idx, len(mp.pools)) {
+		return ErrInvalidPoolIndex
+	}
 	if err = mp.pools[idx].Invoke(args); err == ErrPoolOverload {
-		if fb := mp.lb.Fallback(mp.metrics); fb >= 0 {
+		if fb := mp.lb.Fallback(mp.metrics); validIdx(fb, len(mp.pools)) {
 			return mp.pools[fb].Invoke(args)
 		}
 	}

--- a/multipool_func_generic.go
+++ b/multipool_func_generic.go
@@ -85,7 +85,7 @@ func (mp *MultiPoolWithFuncGeneric[T]) Invoke(args T) (err error) {
 		return ErrInvalidPoolIndex
 	}
 	if err = mp.pools[idx].Invoke(args); err == ErrPoolOverload {
-		if fb := mp.lb.Fallback(mp.metrics); validIdx(fb, len(mp.pools)) {
+		if fb := mp.lb.FallBack(mp.metrics); validIdx(fb, len(mp.pools)) {
 			return mp.pools[fb].Invoke(args)
 		}
 	}

--- a/multipool_func_generic.go
+++ b/multipool_func_generic.go
@@ -24,17 +24,16 @@ package ants
 
 import (
 	"context"
-	"math"
 	"sync/atomic"
 	"time"
 )
 
 // MultiPoolWithFuncGeneric is the generic version of MultiPoolWithFunc.
 type MultiPoolWithFuncGeneric[T any] struct {
-	pools []*PoolWithFuncGeneric[T]
-	index uint32
-	state int32
-	lbs   LoadBalancingStrategy
+	pools   []*PoolWithFuncGeneric[T]
+	metrics []PoolMetrics
+	lb      LoadBalancer
+	state   int32
 }
 
 // NewMultiPoolWithFuncGeneric instantiates a MultiPoolWithFunc with a size of the pool list and a size
@@ -43,11 +42,24 @@ func NewMultiPoolWithFuncGeneric[T any](size, sizePerPool int, fn func(T), lbs L
 	if size <= 0 {
 		return nil, ErrInvalidMultiPoolSize
 	}
+	lb, err := newBuiltinLB(lbs)
+	if err != nil {
+		return nil, err
+	}
+	return NewMultiPoolWithFuncGenericAndLB(size, sizePerPool, fn, lb, options...)
+}
 
-	if lbs != RoundRobin && lbs != LeastTasks {
+// NewMultiPoolWithFuncGenericAndLB instantiates a MultiPoolWithFuncGeneric with a given LoadBalancer.
+func NewMultiPoolWithFuncGenericAndLB[T any](size, sizePerPool int, fn func(T), lb LoadBalancer, options ...Option) (*MultiPoolWithFuncGeneric[T], error) {
+	if size <= 0 {
+		return nil, ErrInvalidMultiPoolSize
+	}
+	if lb == nil {
 		return nil, ErrInvalidLoadBalancingStrategy
 	}
+
 	pools := make([]*PoolWithFuncGeneric[T], size)
+	metrics := make([]PoolMetrics, size)
 	for i := 0; i < size; i++ {
 		pool, err := NewPoolWithFuncGeneric(sizePerPool, fn, options...)
 		if err != nil {
@@ -58,25 +70,9 @@ func NewMultiPoolWithFuncGeneric[T any](size, sizePerPool int, fn func(T), lbs L
 			return nil, err
 		}
 		pools[i] = pool
+		metrics[i] = pool
 	}
-	return &MultiPoolWithFuncGeneric[T]{pools: pools, index: math.MaxUint32, lbs: lbs}, nil
-}
-
-func (mp *MultiPoolWithFuncGeneric[T]) next(lbs LoadBalancingStrategy) (idx int) {
-	switch lbs {
-	case RoundRobin:
-		return int(atomic.AddUint32(&mp.index, 1) % uint32(len(mp.pools)))
-	case LeastTasks:
-		leastTasks := math.MaxInt32
-		for i, pool := range mp.pools {
-			if n := pool.Running(); n < leastTasks {
-				leastTasks = n
-				idx = i
-			}
-		}
-		return
-	}
-	return -1
+	return &MultiPoolWithFuncGeneric[T]{pools: pools, metrics: metrics, lb: lb}, nil
 }
 
 // Invoke submits a task to a pool selected by the load-balancing strategy.
@@ -84,12 +80,11 @@ func (mp *MultiPoolWithFuncGeneric[T]) Invoke(args T) (err error) {
 	if mp.IsClosed() {
 		return ErrPoolClosed
 	}
-
-	if err = mp.pools[mp.next(mp.lbs)].Invoke(args); err == nil {
-		return
-	}
-	if err == ErrPoolOverload && mp.lbs == RoundRobin {
-		return mp.pools[mp.next(LeastTasks)].Invoke(args)
+	idx := mp.lb.Pick(mp.metrics)
+	if err = mp.pools[idx].Invoke(args); err == ErrPoolOverload {
+		if fb := mp.lb.Fallback(mp.metrics); fb >= 0 {
+			return mp.pools[fb].Invoke(args)
+		}
 	}
 	return
 }
@@ -190,7 +185,6 @@ func (mp *MultiPoolWithFuncGeneric[T]) ReleaseContext(ctx context.Context) error
 // Reboot reboots a released multi-pool.
 func (mp *MultiPoolWithFuncGeneric[T]) Reboot() {
 	if atomic.CompareAndSwapInt32(&mp.state, CLOSED, OPENED) {
-		atomic.StoreUint32(&mp.index, 0)
 		for _, pool := range mp.pools {
 			pool.Reboot()
 		}

--- a/multipool_func_generic.go
+++ b/multipool_func_generic.go
@@ -81,8 +81,11 @@ func (mp *MultiPoolWithFuncGeneric[T]) Invoke(args T) (err error) {
 		return ErrPoolClosed
 	}
 	idx := mp.lb.Pick(mp.metrics)
+	if !validIdx(idx, len(mp.pools)) {
+		return ErrInvalidPoolIndex
+	}
 	if err = mp.pools[idx].Invoke(args); err == ErrPoolOverload {
-		if fb := mp.lb.Fallback(mp.metrics); fb >= 0 {
+		if fb := mp.lb.Fallback(mp.metrics); validIdx(fb, len(mp.pools)) {
 			return mp.pools[fb].Invoke(args)
 		}
 	}


### PR DESCRIPTION
### Description of new feature

# PR: Introduce `LoadBalancer` interface for extensible MultiPool load balancing

## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?

New feature — with an internal refactor that is fully backward compatible.

---

## 2. Please describe how these code changes achieve your intention.

### Problem

The current load-balancing strategy in `MultiPool`, `MultiPoolWithFunc`, and `MultiPoolWithFuncGeneric` is implemented as a closed enum (`LoadBalancingStrategy`) with a `switch` inside a `next()` method. This has three limitations:

1. **Not extensible** — users cannot plug in a custom strategy without waiting for upstream changes. For example, a "least-waiting" strategy (picking the pool with the fewest queued tasks) better reflects real backlog pressure under saturation, but there is no way to add it without forking.
2. **Duplicated logic** — `next()` is copy-pasted verbatim across all three MultiPool variants.
3. **State coupling** — the `RoundRobin` counter (`mp.index`) lives on the pool struct rather than the strategy itself.

### Solution

Introduce two interfaces in a new `lbs.go` file:

```go
// PoolMetrics exposes the read-only stats a LoadBalancer needs to make a pick decision.
type PoolMetrics interface {
    Running() int
    Waiting() int
    Free() int
    Cap() int
}

// LoadBalancer picks a pool index from a slice of PoolMetrics.
type LoadBalancer interface {
    Pick(pools []PoolMetrics) int
    // Fallback is called when the pool chosen by Pick is overloaded.
    // Return -1 to indicate no fallback is supported.
    Fallback(pools []PoolMetrics) int
}
```

All three pool types (`*Pool`, `*PoolWithFunc`, `*PoolWithFuncGeneric[T]`) already satisfy `PoolMetrics` via the embedded `*poolCommon` — no extra code needed.

Built-in strategies become small structs:

| Constructor           | Strategy               | Fallback on overload        |
| --------------------- | ---------------------- | --------------------------- |
| `NewRoundRobinLB()`   | Atomic round-robin     | Falls back to least-running |
| `NewLeastTasksLB()`   | Fewest running workers | None                        |
| `NewLeastWaitingLB()` | Fewest waiting tasks   | None                        |

Three new constructors are added — one per MultiPool variant — that accept any `LoadBalancer`:

```go
func NewMultiPoolWithLB(size, sizePerPool int, lb LoadBalancer, options ...Option) (*MultiPool, error)
func NewMultiPoolWithFuncAndLB(size, sizePerPool int, fn func(any), lb LoadBalancer, options ...Option) (*MultiPoolWithFunc, error)
func NewMultiPoolWithFuncGenericAndLB[T any](size, sizePerPool int, fn func(T), lb LoadBalancer, options ...Option) (*MultiPoolWithFuncGeneric[T], error)
```

The existing `NewMultiPool` / `NewMultiPoolWithFunc` / `NewMultiPoolWithFuncGeneric` signatures are **unchanged** — they now delegate to the new constructors internally after converting the enum to the corresponding built-in `LoadBalancer`. Zero breaking changes.

### Custom strategy example

```go
type myLB struct{}

func (m *myLB) Pick(pools []ants.PoolMetrics) int {
    // pick the pool with the most free capacity
    idx, most := 0, -1
    for i, p := range pools {
        if f := p.Free(); f > most {
            most = f
            idx = i
        }
    }
    return idx
}

func (m *myLB) Fallback(pools []ants.PoolMetrics) int { return -1 }

mp, _ := ants.NewMultiPoolWithLB(10, 100, &myLB{})
```

### Why `LeastWaitingLB` is worth adding as a built-in

Benchmarks below show that under mixed workloads (uneven task durations — the most common real-world scenario for IO-bound services), `LeastTasksLB` degrades severely because `Running()` is a poor proxy for actual backlog pressure. `LeastWaitingLB` uses `Waiting()` instead and avoids the problem:

```
goos: windows / goarch: amd64 / cpu: AMD Ryzen 7 5700X
BenchmarkMultiPool_RoundRobin_CPUThroughput-16      70173303     86.76 ns/op    0 B/op   0 allocs/op
BenchmarkMultiPool_LeastTasks_CPUThroughput-16      18660650    330.9  ns/op    0 B/op   0 allocs/op
BenchmarkMultiPool_LeastWaiting_CPUThroughput-16    18016323    331.9  ns/op    0 B/op   0 allocs/op

BenchmarkMultiPool_RoundRobin_IOThroughput-16       40508790    139.5  ns/op    0 B/op   0 allocs/op
BenchmarkMultiPool_LeastTasks_IOThroughput-16       26041756    302.2  ns/op    1 B/op   0 allocs/op
BenchmarkMultiPool_LeastWaiting_IOThroughput-16     19795819    286.1  ns/op    0 B/op   0 allocs/op

BenchmarkMultiPool_RoundRobin_MixedThroughput-16    22110253    254.1  ns/op    1 B/op   0 allocs/op
BenchmarkMultiPool_LeastTasks_MixedThroughput-16    20750173   1864    ns/op    2 B/op   0 allocs/op  ← degrades ~7x
BenchmarkMultiPool_LeastWaiting_MixedThroughput-16  14748758    360.2  ns/op    1 B/op   0 allocs/op
```

`LeastWaitingLB` is also shown as a concrete example of what a custom `LoadBalancer` implementation looks like, making it a useful reference for users building their own strategies.

---

## 3. Please link to the relevant issues (if any).

No existing issue. This PR is self-contained and was designed to be fully backward compatible.

---

## 4. Which documentation changes (if any) need to be made/updated because of this PR?

The README section covering `MultiPool` should be updated to mention:

- The new `NewMultiPoolWithLB` / `NewMultiPoolWithFuncAndLB` / `NewMultiPoolWithFuncGenericAndLB` constructors
- The `LoadBalancer` and `PoolMetrics` interfaces
- A short custom strategy example (similar to the one above)
- The new built-in `NewLeastWaitingLB()` strategy

I am happy to update the README as part of this PR if the overall direction is accepted.

---

## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests pass.
- [ ] I have documented feature info on the README (pending maintainer feedback on the API shape).
- [x] I am willing to help maintain this change if there are issues with it later.

### Scenarios for new feature

- Users running **IO-bound services** with uneven task durations (e.g. mixed fast/slow RPC handlers) who want a smarter pool selection policy
- Users who need **application-specific routing** — e.g. pinning certain task types to specific pools, or implementing priority-based scheduling across pools
- Anyone who wants to experiment with scheduling strategies without waiting for upstream changes

### Breaking changes or not?

No

### Code snippets (optional)

```go

```

### Alternatives for new feature

None.

### Additional context (optional)

None.